### PR TITLE
Added support for UI-router

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -168,9 +168,27 @@ if (typeof module !== 'undefined' && module.exports) {
                         }
                     }
                 };
+                
+                var stateChangeHandler = function (e, nextRoute) {
+                  if (nextRoute && nextRoute.requireADLogin) {
+                    if (!_oauthData.isAuthenticated) {
+                      console.log('Route change event for:' + nextRoute.url);
+                      if (_adal.config && _adal.config.localLoginUrl) {
+                        $location.path(_adal.config.localLoginUrl);
+                      } else {
+                        _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE, nextRoute.url);
+                        console.log('Start login at:' + window.location.href);
+                        $rootScope.$broadcast('adal:loginRedirect');
+                        _adal.login();
+                      }
+                    }
+                  }
+                };
 
                 // Route change event tracking to receive fragment and also auto renew tokens
                 $rootScope.$on('$routeChangeStart', routeChangeHandler);
+                
+                $rootScope.$on('$stateChangeStart', stateChangeHandler);
 
                 $rootScope.$on('$locationChangeStart', locationChangeHandler);
 


### PR DESCRIPTION
Support for UI-Router.

I've tested this with the sample application: https://github.com/AzureADSamples/SinglePageApp-DotNet

Worked fine but required "cacheLocation: 'localStorage'" to be included in the init statement. I tested this with this projects dev branch and it needed the same. Not sure if this is an issue with my browser or using session storage but it's not impacted by this feature.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/69%23issuecomment-70076817%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/69%23issuecomment-70076817%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27ve%20signed%20the%20agreement%2C%20my%20manager%20is%20just%20about%20to%20sign%20his%20part.%22%2C%20%22created_at%22%3A%20%222015-01-15T12%3A08%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1517604%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/BenGale%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/69#issuecomment-70076817'>General Comment</a></b>
- <a href='https://github.com/BenGale'><img border=0 src='https://avatars.githubusercontent.com/u/1517604?v=3' height=16 width=16'></a> I've signed the agreement, my manager is just about to sign his part.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/69?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/69?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/69'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>