### PR TITLE
Add global requireADLogin option

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -153,8 +153,12 @@ if (typeof module !== 'undefined' && module.exports) {
                     }, 1);
                 };
 
+                function isADLoginRequired(route, global) {
+                    return global.requireADLogin ? route.requireADLogin !== false : !!route.requireADLogin;
+                }
+
                 var routeChangeHandler = function (e, nextRoute) {
-                    if (nextRoute && nextRoute.$$route && nextRoute.$$route.requireADLogin) {
+                    if (nextRoute && nextRoute.$$route && isADLoginRequired(nextRoute.$$route, _adal.config)) {
                         if (!_oauthData.isAuthenticated) {
                             console.log('Route change event for:' + $location.$$path);
                             if (_adal.config && _adal.config.localLoginUrl) {
@@ -171,7 +175,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 };
 
                 var stateChangeHandler = function (e, nextRoute) {
-                    if (nextRoute && nextRoute.requireADLogin) {
+                    if (nextRoute && isADLoginRequired(nextRoute, _adal.config)) {
                         if (!_oauthData.isAuthenticated) {
                             console.log('Route change event for:' + nextRoute.url);
                             if (_adal.config && _adal.config.localLoginUrl) {


### PR DESCRIPTION
Adds a global `requireADLogin` option to the ADAL config. You can specify when configuring the provider:

    adalAuthenticationServiceProvider.init({
        tenant: '<tenant name>',
        clientId: '<client ID>',
        requireADLogin: true
    }, $httpProvider);

The global value for `requireADLogin` will be used whenever there is **no** `requireADLogin` property on the route (or when it is `null` or `undefined`). The route's `requireADLogin`  will always override the global one so setting the route's `requireADLogin` property to `false` will override the global `true`, resulting in AD login *not* being required for this route.

This will make things easier when a lot of routes, if not all routes, require login.

*This relates to issue #96.*
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/97%23issuecomment-78212396%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/97%23issuecomment-82602601%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/97%23issuecomment-78212396%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40richardp-au__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20This%20seems%20like%20a%20small%20%28but%20important%29%20contribution%2C%20so%20no%20Contribution%20License%20Agreement%20is%20required%20at%20this%20point.%20Real%20humans%20will%20now%20evaluate%20your%20PR.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-03-11T06%3A33%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20looks%20like%20existing%20route%20protection%20behavior%20will%20stay%20if%20developer%20does%20not%20set%20global%20option%20to%20true.%20Their%20app%20behavior%20should%20stay%20same%20when%20they%20get%20new%20version.%20%20We%20want%20developer%20to%20use%20explicit%20flag%20to%20make%20all%20routes%20protected.%20I%20like%20the%20overwrite%20option.%22%2C%20%22created_at%22%3A%20%222015-03-17T21%3A11%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/97#issuecomment-78212396'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@richardp-au__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>
This seems like a small (but important) contribution, so no Contribution License Agreement is required at this point. Real humans will now evaluate your PR.
</span>
TTYL, MSOTBOT;
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> It looks like existing route protection behavior will stay if developer does not set global option to true. Their app behavior should stay same when they get new version.  We want developer to use explicit flag to make all routes protected. I like the overwrite option.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/97?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/97?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/97'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>