### PR TITLE
make sure that all logging is consistently done via _logstatus()

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -159,13 +159,13 @@ if (typeof module !== 'undefined' && module.exports) {
                 };
 
                 var loginHandler = function () {
-                    console.log('Login event for:' + $location.$$path);
+                    _adal._logstatus('Login event for:' + $location.$$path);
                     if (_adal.config && _adal.config.localLoginUrl) {
                         $location.path(_adal.config.localLoginUrl);
                     } else {
                         // directly start login flow
                         _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE, $location.$$path);
-                        console.log('Start login at:' + window.location.href);
+                        _adal._logstatus('Start login at:' + window.location.href);
                         $rootScope.$broadcast('adal:loginRedirect');
                         _adal.login();
                     }
@@ -178,7 +178,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 var routeChangeHandler = function (e, nextRoute) {
                     if (nextRoute && nextRoute.$$route && isADLoginRequired(nextRoute.$$route, _adal.config)) {
                         if (!_oauthData.isAuthenticated) {
-                            console.log('Route change event for:' + $location.$$path);
+                            _adal._logstatus('Route change event for:' + $location.$$path);
                             loginHandler();
                         }
                     }
@@ -187,7 +187,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 var stateChangeHandler = function (e, nextRoute) {
                     if (nextRoute && isADLoginRequired(nextRoute, _adal.config)) {
                         if (!_oauthData.isAuthenticated) {
-                            console.log('State change event for:' + $location.$$path);
+                            _adal._logstatus('State change event for:' + $location.$$path);
                             loginHandler();
                         }
                     }
@@ -322,6 +322,6 @@ if (typeof module !== 'undefined' && module.exports) {
             };
         }]);
     } else {
-        console.log('Angular.JS is not included');
+        console.error('Angular.JS is not included');
     }
 }());

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -729,11 +729,11 @@ AuthenticationContext.prototype.handleWindowCallback = function () {
             requestInfo.requestType === this.REQUEST_TYPE.ID_TOKEN) &&
             window.parent) {
             // iframe call but same single page
-            console.log('Window is in iframe');
+            this._logstatus('Window is in iframe');
             callback = window.parent.AuthenticationContext().callback;
             window.src = '';
         } else if (window && window.oauth2Callback) {
-            console.log('Window is redirecting');
+            this._logstatus('Window is redirecting');
             callback = this.callback;
         }
 
@@ -761,7 +761,7 @@ AuthenticationContext.prototype._getNavigateUrl = function (responseType, resour
     }
 
     var urlNavigate = this.instance + tenant + '/oauth2/authorize' + this._serialize(responseType, this.config, resource) + this._addClientId();
-    console.log('Navigate url:' + urlNavigate);
+    this._logstatus('Navigate url:' + urlNavigate);
     return urlNavigate;
 };
 


### PR DESCRIPTION
replaced all 'console.log' calls with _logstatus() in order to allow users to override logging by supplying their own implementation of AuthenticationContext._logstatus().
more context: adal library seems to have a verbose diagnostic output and creates a lot of noise in the log console making it harder to find application-specific log output.

also changed console.log('Angular.JS is not included') to console.error().
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/106%23issuecomment-90771455%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/106%23issuecomment-90903332%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/106%23issuecomment-90771455%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40vadimm__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20In%20order%20for%20us%20to%20evaluate%20and%20accept%20your%20PR%2C%20we%20ask%20that%20you%20sign%20a%20contribution%20license%20agreement.%20It%27s%20all%20electronic%20and%20will%20take%20just%20minutes.%20I%20promise%20there%27s%20no%20faxing.%20https%3A//cla2.msopentech.com.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-04-08T01%3A00%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20only%20change%20in%20logging%20related%20calls%2C%20so%20ok%20without%20cla%20form.%22%2C%20%22created_at%22%3A%20%222015-04-08T12%3A45%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/106#issuecomment-90771455'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@vadimm__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>
In order for us to evaluate and accept your PR, we ask that you sign a contribution license agreement. It's all electronic and will take just minutes. I promise there's no faxing. https://cla2.msopentech.com.
</span>
TTYL, MSOTBOT;
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> It is only change in logging related calls, so ok without cla form.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/106?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/106?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/106'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>