### PR TITLE
Added fallback to ID_TOKEN on token renewal response (fix issue #110)

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -740,7 +740,7 @@ AuthenticationContext.prototype.handleWindowCallback = function () {
         window.location.hash = '';
         window.location = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
         if (requestInfo.requestType === this.REQUEST_TYPE.RENEW_TOKEN) {
-            callback(this._getItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN]);
+            callback(this._getItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN] || || requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
             return;
         } else if (requestInfo.requestType === this.REQUEST_TYPE.ID_TOKEN) {
             // JS context may not have the user if callback page was different, so parse idtoken again to callback


### PR DESCRIPTION
I'm using adal.js without the angular module. I've seen that when the token was expired and thus silently refreshed, the library was calling the acquireToken() callback with an empty error string and 'undefined' value for the token. I've inspected the requestInfo object in the handleWindowCallback method and found that the renewed token came in the 'id_token' field, instead of the 'access_token' field (case requestInfo.requestType === this.REQUEST_TYPE.RENEW_TOKEN)

![image](https://cloud.githubusercontent.com/assets/821193/7239960/111fdfde-e784-11e4-8349-816add9629d9.png)

I've made the following change in the handleWindowCallback() method:

![image](https://cloud.githubusercontent.com/assets/821193/7239983/3a616e8a-e784-11e4-8b51-747a2f19155c.png)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/112%23issuecomment-95160330%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/112%23issuecomment-95160330%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40sdurandeu__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20This%20seems%20like%20a%20small%20%28but%20important%29%20contribution%2C%20so%20no%20Contribution%20License%20Agreement%20is%20required%20at%20this%20point.%20Real%20humans%20will%20now%20evaluate%20your%20PR.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-04-22T12%3A45%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/112#issuecomment-95160330'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@sdurandeu__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>
This seems like a small (but important) contribution, so no Contribution License Agreement is required at this point. Real humans will now evaluate your PR.
</span>
TTYL, MSOTBOT;


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/112?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/112?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/112'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>