### PR TITLE
check domain_hint query param existence before adding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ bower_components
 
 #copied adal
 samples/owin/OwinSample/Scripts/adal.js
+
+#webstorm
+.idea

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -20,7 +20,8 @@
 
 // node.js usage for tests
 var Logging = {
-    log: function () { },
+    log: function () {
+    },
 };
 
 var AuthenticationContext;
@@ -42,11 +43,11 @@ if (typeof module !== 'undefined' && module.exports) {
  */
 
 /**
-* User information from idtoken.
-*  @class User
-*  @property {string} userName - username assigned from upn or email.
-*  @property {object} profile - properties parsed from idtoken.
-*/
+ * User information from idtoken.
+ *  @class User
+ *  @property {string} userName - username assigned from upn or email.
+ *  @property {object} profile - properties parsed from idtoken.
+ */
 
 /**
  * Creates a new AuthenticationContext object.
@@ -56,9 +57,9 @@ if (typeof module !== 'undefined' && module.exports) {
  **/
 AuthenticationContext = function (config) {
     /**
-    * Enum for request type
-    * @enum {string}
-    */
+     * Enum for request type
+     * @enum {string}
+     */
     this.REQUEST_TYPE = {
         LOGIN: 'LOGIN',
         RENEW_TOKEN: 'RENEW_TOKEN',
@@ -67,9 +68,9 @@ AuthenticationContext = function (config) {
     };
 
     /**
-    * Enum for storage constants
-    * @enum {string}
-    */
+     * Enum for storage constants
+     * @enum {string}
+     */
     this.CONSTANTS = {
         ACCESS_TOKEN: 'access_token',
         EXPIRES_IN: 'expires_in',
@@ -188,10 +189,10 @@ AuthenticationContext.prototype._hasResource = function (key) {
 };
 
 /**
-* Gets token for the specified resource from local storage cache
-* @param {string}   resource A URI that identifies the resource for which the token is valid.
-* @returns {string} token if exists and not expired or null
-*/
+ * Gets token for the specified resource from local storage cache
+ * @param {string}   resource A URI that identifies the resource for which the token is valid.
+ * @returns {string} token if exists and not expired or null
+ */
 AuthenticationContext.prototype.getCachedToken = function (resource) {
     if (!this._hasResource(resource)) {
         return null;
@@ -213,9 +214,9 @@ AuthenticationContext.prototype.getCachedToken = function (resource) {
 };
 
 /**
-* Retrieves and parse idToken from localstorage
-* @returns {User} user object
-*/
+ * Retrieves and parse idToken from localstorage
+ * @returns {User} user object
+ */
 AuthenticationContext.prototype.getCachedUser = function () {
     if (this._user) {
         return this._user;
@@ -250,10 +251,10 @@ AuthenticationContext.prototype.registerCallback = function (expectedState, reso
 // callback(errorResponse, token)
 // with callback
 /**
-* Acquires access token with hidden iframe
-* @param {string}   resource  ResourceUri identifying the target resource
-* @returns {string} access token if request is successfull
-*/
+ * Acquires access token with hidden iframe
+ * @param {string}   resource  ResourceUri identifying the target resource
+ * @returns {string} access token if request is successfull
+ */
 AuthenticationContext.prototype._renewToken = function (resource, callback) {
     // use iframe to try refresh token
     // use given resource to create new authz url
@@ -274,7 +275,12 @@ AuthenticationContext.prototype._renewToken = function (resource, callback) {
 
     this._logstatus('Renew token Expected state: ' + expectedState);
     var urlNavigate = this._getNavigateUrl('token', resource) + '&prompt=none&login_hint=' + encodeURIComponent(this._user.userName);
-    urlNavigate += '&domain_hint=' + encodeURIComponent(this._getDomainHint());
+
+    // don't add domain_hint twice if user provided it in the extraQueryParameter value
+    if (!this._urlContainsQueryStringParameter("domain_hint", urlNavigate)) {
+        urlNavigate += '&domain_hint=' + encodeURIComponent(this._getDomainHint());
+    }
+
     urlNavigate += '&nonce=' + encodeURIComponent(this._idTokenNonce);
     this.callback = callback;
     this.registerCallback(expectedState, resource, callback);
@@ -306,7 +312,12 @@ AuthenticationContext.prototype._renewIdToken = function (callback) {
 
     this._logstatus('Renew token Expected state: ' + expectedState);
     var urlNavigate = this._getNavigateUrl('id_token', null) + '&prompt=none&login_hint=' + encodeURIComponent(this._user.userName);
-    urlNavigate += '&domain_hint=' + encodeURIComponent(this._getDomainHint());
+
+    // don't add domain_hint twice if user provided it in the extraQueryParameter value
+    if (!this._urlContainsQueryStringParameter("domain_hint", urlNavigate)) {
+        urlNavigate += '&domain_hint=' + encodeURIComponent(this._getDomainHint());
+    }
+
     urlNavigate += '&nonce=' + encodeURIComponent(this._idTokenNonce);
     this.registerCallback(expectedState, this.config.clientId, callback);
     this.idTokenNonce = null;
@@ -316,6 +327,12 @@ AuthenticationContext.prototype._renewIdToken = function (callback) {
     this._loadFrame(urlNavigate, 'adalIdTokenFrame');
 };
 
+AuthenticationContext.prototype._urlContainsQueryStringParameter = function (name, url) {
+    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+        results = regex.exec(url);
+    return results !== null;
+}
 
 AuthenticationContext.prototype._loadFrame = function (urlNavigate, frameName) {
     // This trick overcomes iframe navigation in IE
@@ -333,10 +350,10 @@ AuthenticationContext.prototype._loadFrame = function (urlNavigate, frameName) {
 };
 
 /**
-* Acquire token from cache if not expired and available. Acquires token from iframe if expired.
-* @param {string}   resource  ResourceUri identifying the target resource
-* @param {requestCallback} callback 
-*/
+ * Acquire token from cache if not expired and available. Acquires token from iframe if expired.
+ * @param {string}   resource  ResourceUri identifying the target resource
+ * @param {requestCallback} callback
+ */
 AuthenticationContext.prototype.acquireToken = function (resource, callback) {
     if (this._isEmpty(resource)) {
         callback('resource is required', null);
@@ -380,9 +397,9 @@ AuthenticationContext.prototype.acquireToken = function (resource, callback) {
 };
 
 /**
-* Redirect the Browser to Azure AD Authorization endpoint
-* @param {string}   urlNavigate The authorization request url
-*/
+ * Redirect the Browser to Azure AD Authorization endpoint
+ * @param {string}   urlNavigate The authorization request url
+ */
 AuthenticationContext.prototype.promptUser = function (urlNavigate) {
     if (urlNavigate) {
         this._logstatus('Navigate to:' + urlNavigate);
@@ -393,8 +410,8 @@ AuthenticationContext.prototype.promptUser = function (urlNavigate) {
 };
 
 /**
-* Clear cache items.
-*/
+ * Clear cache items.
+ */
 AuthenticationContext.prototype.clearCache = function () {
     this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY, '');
     this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY, 0);
@@ -421,8 +438,8 @@ AuthenticationContext.prototype.clearCache = function () {
 };
 
 /**
-* Clear cache items for a resource.
-*/
+ * Clear cache items for a resource.
+ */
 AuthenticationContext.prototype.clearCacheForResource = function (resource) {
     this._saveItem(this.CONSTANTS.STORAGE.FAILED_RENEW, '');
     this._saveItem(this.CONSTANTS.STORAGE.STATE_RENEW, '');
@@ -436,9 +453,9 @@ AuthenticationContext.prototype.clearCacheForResource = function (resource) {
 };
 
 /**
-* Logout user will redirect page to logout endpoint. 
-* After logout, it will redirect to post_logout page if provided.
-*/
+ * Logout user will redirect page to logout endpoint.
+ * After logout, it will redirect to post_logout page if provided.
+ */
 AuthenticationContext.prototype.logOut = function () {
     this.clearCache();
     var tenant = 'common';
@@ -556,10 +573,10 @@ AuthenticationContext.prototype.isCallback = function (hash) {
     hash = this._getHash(hash);
     var parameters = this._deserialize(hash);
     return (
-            parameters.hasOwnProperty(this.CONSTANTS.ERROR_DESCRIPTION) ||
-            parameters.hasOwnProperty(this.CONSTANTS.ACCESS_TOKEN) ||
-            parameters.hasOwnProperty(this.CONSTANTS.ID_TOKEN)
-            );
+        parameters.hasOwnProperty(this.CONSTANTS.ERROR_DESCRIPTION) ||
+        parameters.hasOwnProperty(this.CONSTANTS.ACCESS_TOKEN) ||
+        parameters.hasOwnProperty(this.CONSTANTS.ID_TOKEN)
+    );
 };
 
 /**
@@ -577,7 +594,13 @@ AuthenticationContext.prototype.getLoginError = function () {
 AuthenticationContext.prototype.getRequestInfo = function (hash) {
     hash = this._getHash(hash);
     var parameters = this._deserialize(hash);
-    var requestInfo = { valid: false, parameters: {}, stateMatch: false, stateResponse: '', requestType: this.REQUEST_TYPE.UNKNOWN };
+    var requestInfo = {
+        valid: false,
+        parameters: {},
+        stateMatch: false,
+        stateResponse: '',
+        requestType: this.REQUEST_TYPE.UNKNOWN
+    };
     if (parameters) {
         requestInfo.parameters = parameters;
         if (parameters.hasOwnProperty(this.CONSTANTS.ERROR_DESCRIPTION) ||
@@ -903,7 +926,9 @@ AuthenticationContext.prototype._deserialize = function (query) {
     var match,
         pl = /\+/g,  // Regex for replacing addition symbol with a space
         search = /([^&=]+)=?([^&]*)/g,
-        decode = function (s) { return decodeURIComponent(s.replace(pl, ' ')); },
+        decode = function (s) {
+            return decodeURIComponent(s.replace(pl, ' '));
+        },
         obj = {};
     match = search.exec(query);
     while (match) {
@@ -1096,7 +1121,7 @@ AuthenticationContext.prototype._log = function (resource, message) {
     var correlationId = this.config.correlationId;
     var timestamp = new Date().toUTCString();
 
-    var formattedMessage = timestamp + ':' + correlationId + ': ' + resource + ':' + message + ';'  ;
+    var formattedMessage = timestamp + ':' + correlationId + ': ' + resource + ':' + message + ';';
 
     Logging.log(formattedMessage);
 };

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -328,10 +328,9 @@ AuthenticationContext.prototype._renewIdToken = function (callback) {
 };
 
 AuthenticationContext.prototype._urlContainsQueryStringParameter = function (name, url) {
-    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-        results = regex.exec(url);
-    return results !== null;
+    // regex to detect pattern of a ? or & followed by the name parameter and an equals character
+    var regex = new RegExp("[\\?&]" + name + "=");
+    return regex.test(url);
 }
 
 AuthenticationContext.prototype._loadFrame = function (urlNavigate, frameName) {


### PR DESCRIPTION
When adding a domain_hint to the extraQueryParameter field, the
domain_hint query parameter is appended multiple times on subsequent
requests to obtain a token in an iframe. This causes the login to fail.
This fixes checks for the existence of the domain_hint parameter prior
to adding it.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23issuecomment-130807770%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23issuecomment-130809879%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23issuecomment-130812325%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23issuecomment-133185830%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23issuecomment-134373093%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23discussion_r37579218%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23discussion_r37580351%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23discussion_r37584001%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23issuecomment-130807770%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40wakurth__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20In%20order%20for%20us%20to%20evaluate%20and%20accept%20your%20PR%2C%20we%20ask%20that%20you%20sign%20a%20contribution%20license%20agreement.%20It%27s%20all%20electronic%20and%20will%20take%20just%20minutes.%20I%20promise%20there%27s%20no%20faxing.%20https%3A//cla.microsoft.com.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-13T19%3A11%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22__%40wakurth__%2C%20Thanks%20for%20signing%20the%20contribution%20license%20agreement%20so%20quickly%21%20Actual%20humans%20will%20now%20validate%20the%20agreement%20and%20then%20evaluate%20the%20PR.%5Cr%5Cn%3Cbr%20/%3EThanks%2C%20MSBOT%3B%22%2C%20%22created_at%22%3A%20%222015-08-13T19%3A20%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-08-13T19%3A28%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1013700%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wakurth%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-08-20T21%3A36%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1013700%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wakurth%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T20%3A39%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ddd2738b770554352f469a0de2f9771d37651667%20lib/adal.js%20130%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/158%23discussion_r37579218%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40wakurth%20Could%20you%20comment%20this%20a%20bit.%20%20I%20don%27t%20understand%20what%20line%20331%20is%20doing.%5Cr%5Cn%5Cr%5CnWouldn%27t%20the%20regex%5Cr%5Cn%5Cr%5Cn%3E%20%5B%3F%26%5Dname%3D%5Cr%5Cn%5Cr%5CnAccomplish%20the%20same%20thing%20simpler%3F%20%20The%20capture%20group%20is%20superfluous.%20%20I%20think%20you%20can%20just%20use%20regex.test%28url%29.%22%2C%20%22created_at%22%3A%20%222015-08-20T20%3A47%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40RandalliLama%20...%20Thank%20you%20for%20the%20response.%20I%27ll%20look%20at%20simplifying%20that%2C%20and%20re-submit%20an%20update.%22%2C%20%22created_at%22%3A%20%222015-08-20T20%3A57%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1013700%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wakurth%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-20T21%3A35%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1013700%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wakurth%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/adal.js%3AL327-339%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%2C%20%22https%3A//github.com/wakurth%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1013700%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a><a href='https://github.com/wakurth'><img src='https://avatars.githubusercontent.com/u/1013700?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/158#issuecomment-130807770'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@wakurth__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<span>
In order for us to evaluate and accept your PR, we ask that you sign a contribution license agreement. It's all electronic and will take just minutes. I promise there's no faxing. https://cla.microsoft.com.
</span>
TTYL, MSBOT;
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> __@wakurth__, Thanks for signing the contribution license agreement so quickly! Actual humans will now validate the agreement and then evaluate the PR.
<br />Thanks, MSBOT;
- [x] <a href='#crh-comment-Pull ddd2738b770554352f469a0de2f9771d37651667 lib/adal.js 130'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/158#discussion_r37579218'>File: lib/adal.js:L327-339</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @wakurth Could you comment this a bit.  I don't understand what line 331 is doing.
Wouldn't the regex
> [?&]name=
Accomplish the same thing simpler?  The capture group is superfluous.  I think you can just use regex.test(url).
- <a href='https://github.com/wakurth'><img border=0 src='https://avatars.githubusercontent.com/u/1013700?v=3' height=16 width=16'></a> @RandalliLama ... Thank you for the response. I'll look at simplifying that, and re-submit an update.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/158?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/158?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/158?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/158'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>