### PR TITLE
Added hash parameter to handleWindowCallback

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -758,10 +758,14 @@ AuthenticationContext.prototype.getResourceForEndpoint = function (endpoint) {
 };
 
 /*exported  oauth2Callback */
-AuthenticationContext.prototype.handleWindowCallback = function () {
+AuthenticationContext.prototype.handleWindowCallback = function (hash) {
     // This is for regular javascript usage for redirect handling
     // need to make sure this is for callback
-    var hash = window.location.hash;
+    var hashFromWindowLocation = false;
+    if (typeof hash === 'undefined') {
+        hash = window.location.hash;
+        hashFromWindowLocation = true;
+    }
     if (this.isCallback(hash)) {
         var requestInfo = this.getRequestInfo(hash);
         this.info('Returned from redirect url');
@@ -779,8 +783,10 @@ AuthenticationContext.prototype.handleWindowCallback = function () {
             callback = this.callback;
         }
         
-        window.location.hash = '';
-        window.location = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
+        if (hashFromWindowLocation) {
+            window.location.hash = '';
+            window.location = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
+        }
         if (requestInfo.requestType === this.REQUEST_TYPE.RENEW_TOKEN) {
             callback(this._getItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN] || requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
             return;


### PR DESCRIPTION
To allow for scenarios where the login flow takes place in a window
different than the main one (such as a popup), the 
`handleWindowCallback` function cannot assume that the hash 
always comes from `window.location` or that `window.location` 
should be replaced by a cached location after the callback has been 
handled.

A hash parameter is introduced and will be used by the function if
present - otherwise it falls back to `window.location.hash` as before.
Also, `window.location.hash` and `window.location` are only overwritten
by the function when the hash in question was indeed read from
`window.location`.

This works well in conjunction with a custom `config.displayCall` 
function that uses some other window than the main one to display
the Azure AD login page; the app then needs to manually call
`handleWindowCallback`, but will want to extract the hash from the
other window and supply it as an argument.

All in all a pretty minor change to adal.js but opening up for a broader
set of applications (such as the one discussed in #129).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-132340383%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-132344571%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-138255380%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-143392925%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-143405416%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-143898544%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-143942964%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-144145609%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-132340383%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40Hihaj__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20This%20seems%20like%20a%20small%20%28but%20important%29%20contribution%2C%20so%20no%20Contribution%20License%20Agreement%20is%20required%20at%20this%20point.%20Real%20humans%20will%20now%20evaluate%20your%20PR.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-18T20%3A25%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22For%20an%20example%20of%20how%20this%20can%20be%20useful%2C%20see%20%5Bthis%20gist%5D%28https%3A//gist.github.com/Hihaj/6e77813d730ebf4ebe7c%23file-adal-app-js-L31%29.%22%2C%20%22created_at%22%3A%20%222015-08-18T20%3A42%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/905731%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Hihaj%22%7D%7D%2C%20%7B%22body%22%3A%20%22Comments%20on%20this%2C%20anyone%3F%22%2C%20%22created_at%22%3A%20%222015-09-07T09%3A53%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/905731%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Hihaj%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20thought%20we%27ve%20already%20discussed%20about%20this.%20We%20could%20simply%20add%20a%20new%20parameter%20in%20handlewindowcallback.%20%22%2C%20%22created_at%22%3A%20%222015-09-26T02%3A46%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40weijjia%20Yes%2C%20that%27s%20what%20I%20did%20in%20the%20PR.%20%22%2C%20%22created_at%22%3A%20%222015-09-26T07%3A09%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/905731%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Hihaj%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20sorry%2C%20i%20mean%20we%20could%20not%20simply%20add%20a%20new%20param%20in%20the%20handlewindowcallback.%20%22%2C%20%22created_at%22%3A%20%222015-09-28T23%3A10%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20is%20the%20original%20discussion%20available%20somewhere%3F%20And%20do%20you%20have%20an%5Cnalternative%20solution%20or%20workaround%20for%20this%20scenario%3F%5Cntis%2029%20sep.%202015%20kl.%2001%3A10%20skrev%20Wei%20Jia%20%3Cnotifications%40github.com%3E%3A%5Cn%5Cn%3E%20Ah%2C%20sorry%2C%20i%20mean%20we%20could%20not%20simply%20add%20a%20new%20param%20in%20the%5Cn%3E%20handlewindowcallback.%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/160%23issuecomment-143898544%3E%5Cn%3E%20.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-29T04%3A44%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/905731%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Hihaj%22%7D%7D%2C%20%7B%22body%22%3A%20%22Haven%27t%20you%20already%20sent%20our%20email%20for%20discussing%20this%20before%3F%20If%20not%2C%20could%20you%20tell%20me%20why%20you%20want%20to%20do%20this%3F%22%2C%20%22created_at%22%3A%20%222015-09-29T18%3A23%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/160#issuecomment-132340383'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@Hihaj__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<span>
This seems like a small (but important) contribution, so no Contribution License Agreement is required at this point. Real humans will now evaluate your PR.
</span>
TTYL, MSBOT;
- <a href='https://github.com/Hihaj'><img border=0 src='https://avatars.githubusercontent.com/u/905731?v=3' height=16 width=16'></a> For an example of how this can be useful, see [this gist](https://gist.github.com/Hihaj/6e77813d730ebf4ebe7c#file-adal-app-js-L31).
- <a href='https://github.com/Hihaj'><img border=0 src='https://avatars.githubusercontent.com/u/905731?v=3' height=16 width=16'></a> Comments on this, anyone?
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> I thought we've already discussed about this. We could simply add a new parameter in handlewindowcallback.
- <a href='https://github.com/Hihaj'><img border=0 src='https://avatars.githubusercontent.com/u/905731?v=3' height=16 width=16'></a> @weijjia Yes, that's what I did in the PR.
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> Ah, sorry, i mean we could not simply add a new param in the handlewindowcallback.
- <a href='https://github.com/Hihaj'><img border=0 src='https://avatars.githubusercontent.com/u/905731?v=3' height=16 width=16'></a> Ok, is the original discussion available somewhere? And do you have an
alternative solution or workaround for this scenario?
tis 29 sep. 2015 kl. 01:10 skrev Wei Jia <notifications@github.com>:
> Ah, sorry, i mean we could not simply add a new param in the
> handlewindowcallback.
>
> —
> Reply to this email directly or view it on GitHub
> <https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/160#issuecomment-143898544>
> .
>
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> Haven't you already sent our email for discussing this before? If not, could you tell me why you want to do this?


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/160?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/160?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/160'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>