### PR TITLE
support base64 decoding in ie9

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -884,7 +884,8 @@ AuthenticationContext.prototype._base64DecodeStringUrlSafe = function (base64IdT
 //Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference. 
 AuthenticationContext.prototype._decode = function (base64IdToken) {
     var codes = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-    base64IdToken = String(base64IdToken).replace(/=+&/, '');
+    base64IdToken = String(base64IdToken).replace(/=+$/, '');
+
     var length = base64IdToken.length;
     if (length % 4 === 1) {
         throw new Error('The token to be decoded is not correctly encoded.');

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -881,25 +881,51 @@ AuthenticationContext.prototype._base64DecodeStringUrlSafe = function (base64IdT
     }
 };
 
-//reference https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js
+//Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference. 
 AuthenticationContext.prototype._decode = function (base64IdToken) {
     var codes = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-    var idTokenToDecode = String(base64IdToken).replace(/=+$/, '');
-    
-    if (idTokenToDecode.length % 4 === 1) {
-        throw new Error('The token to be decoded is not correctly encoded');
+    base64IdToken = String(base64IdToken).replace(/=+&/, '');
+    var length = base64IdToken.length;
+    if (length % 4 === 1) {
+        throw new Error('The token to be decoded is not correctly encoded.');
     }
     
-    var output = '', bitCount = 0, bitStorage, buffer, length = idTokenToDecode.length;
-    for (var index = 0; index < length; index++) {
-        buffer = codes.indexOf(idTokenToDecode.charAt(index));
-        bitStorage = bitCount % 4 ? bitStorage * 64 + buffer : buffer;
+    var h1, h2, h3, h4, bits, c1, c2, c3, decoded = '';
+    for (var i = 0; i < length; i += 4) {
+        //Every 4 base64 encoded character will be converted to 3 byte string, which is 24 bits
+        // then 6 bits per base64 encoded character
+        h1 = codes.indexOf(base64IdToken.charAt(i));
+        h2 = codes.indexOf(base64IdToken.charAt(i + 1));
+        h3 = codes.indexOf(base64IdToken.charAt(i + 2));
+        h4 = codes.indexOf(base64IdToken.charAt(i + 3));
         
-        if (bitCount++ % 4) {
-            output += String.fromCharCode(255 & bitStorage >> (-2 * bitCount & 6));
+        // For padding, if last two are '='
+        if (i + 2 === length - 1) {
+            bits = h1 << 18 | h2 << 12 | h3 << 6;
+            c1 = bits >> 16 & 255;
+            c2 = bits >> 8 & 255;
+            decoded += String.fromCharCode(c1, c2);
+            break;
         }
+        // if last one is '='
+        else if (i + 1 === length - 1) {
+            bits = h1 << 18 | h2 << 12
+            c1 = bits >> 16 & 255;
+            decoded += String.fromCharCode(c1);
+            break;
+        }
+        
+        bits = h1 << 18 | h2 << 12 | h3 << 6 | h4;
+        
+        // then convert to 3 byte chars
+        c1 = bits >> 16 & 255;
+        c2 = bits >> 8 & 255;
+        c3 = bits & 255;
+        
+        decoded += String.fromCharCode(c1, c2, c3);
     }
-    return output;
+    
+    return decoded;
 };
 
 // Adal.node js crack function

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1,4 +1,4 @@
-//----------------------------------------------------------------------
+﻿//----------------------------------------------------------------------
 // AdalJS v1.0.5
 // @preserve Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
@@ -876,10 +876,30 @@ AuthenticationContext.prototype._base64DecodeStringUrlSafe = function (base64IdT
     if (window.atob) {
         return decodeURIComponent(escape(window.atob(base64IdToken))); // jshint ignore:line
     }
+    else {
+        return decodeURIComponent(escape(this._decode(base64IdToken)));
+    }
+};
+
+//reference https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js
+AuthenticationContext.prototype._decode = function (base64IdToken) {
+    var codes = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+    var idTokenToDecode = String(base64IdToken).replace(/=+$/, '');
     
-    // TODO add support for this
-    this.warn('Browser is not supported');
-    return null;
+    if (idTokenToDecode.length % 4 === 1) {
+        throw new Error('The token to be decoded is not correctly encoded');
+    }
+    
+    var output = '', bitCount = 0, bitStorage, buffer, length = idTokenToDecode.length;
+    for (var index = 0; index < length; index++) {
+        buffer = codes.indexOf(idTokenToDecode.charAt(index));
+        bitStorage = bitCount % 4 ? bitStorage * 64 + buffer : buffer;
+        
+        if (bitCount++ % 4) {
+            output += String.fromCharCode(255 & bitStorage >> (-2 * bitCount & 6));
+        }
+    }
+    return output;
 };
 
 // Adal.node js crack function

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -591,11 +591,11 @@ describe('Adal', function () {
     });
 
     it ('test decode with one = padding', function () {
-        expect(adal._decode('ZGVjb2RlIHRlc3Rz=')).toBe('decode tests');        
+        expect(adal._decode('ZWNvZGUgdGVzdHM=')).toBe('ecode tests');        
     });
 
     it ('test decode with two == padding', function () {
-        expect(adal._decode('ZGVjb2RlIHRlc3Rz==')).toBe('decode tests');        
+        expect(adal._decode('Y29kZSB0ZXN0cw==')).toBe('code tests');        
     })
 
     it ('test decode throw error', function () {

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -587,15 +587,15 @@ describe('Adal', function () {
     });
 
     it ('test decode with no padding', function () {
-        expect(adal._decode('YW55IGNhcm5hbCBwbGVhc3Vy')).toBe('any carnal pleasur');
+        expect(adal._decode('ZGVjb2RlIHRlc3Rz')).toBe('decode tests');
     });
 
     it ('test decode with one = padding', function () {
-        expect(adal._decode('YW55IGNhcm5hbCBwbGVhc3U=')).toBe('any carnal pleasu');        
+        expect(adal._decode('ZGVjb2RlIHRlc3Rz=')).toBe('decode tests');        
     });
 
     it ('test decode with two == padding', function () {
-        expect(adal._decode('YW55IGNhcm5hbCBwbGVhcw==')).toBe('any carnal pleas');        
+        expect(adal._decode('ZGVjb2RlIHRlc3Rz==')).toBe('decode tests');        
     })
 
     it ('test decode throw error', function () {

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -586,6 +586,26 @@ describe('Adal', function () {
         expect(storageFake.getItem(adal.CONSTANTS.STORAGE.USERNAME)).toBeUndefined();
     });
 
+    it ('test decode with no padding', function () {
+        expect(adal._decode('YW55IGNhcm5hbCBwbGVhc3Vy')).toBe('any carnal pleasur');
+    });
+
+    it ('test decode with one = padding', function () {
+        expect(adal._decode('YW55IGNhcm5hbCBwbGVhc3U=')).toBe('any carnal pleasu');        
+    });
+
+    it ('test decode with two == padding', function () {
+        expect(adal._decode('YW55IGNhcm5hbCBwbGVhcw==')).toBe('any carnal pleas');        
+    })
+
+    it ('test decode throw error', function () {
+        try{
+           adal._decode('YW55I');
+        } catch(e) {
+            expect(e.message).toBe('The token to be decoded is not correctly encoded.');
+        }
+    });
+
     // TODO angular intercepptor
    
     // TODO angular authenticaitonService


### PR DESCRIPTION
fix for issue #159, support base64 decoding in ie9.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23issuecomment-146006898%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23issuecomment-146926885%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23issuecomment-147808854%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23issuecomment-147809107%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23issuecomment-147866653%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23discussion_r41901881%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23discussion_r41912954%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23discussion_r41913868%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23discussion_r41915111%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23discussion_r41918249%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/commit/abc94d6af828fb66c47026e41efb8089e6c7921d%23commitcomment-13747781%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/commit/f99a7fea96281f9ee847d20b19142d0b2900c2a2%23commitcomment-13747834%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23issuecomment-146006898%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20add%20tests%20for%20this.%20%20If%20you%20can%20track%20down%20existing%20tests%2C%20perhaps%20from%20the%20.NET%20team%2C%20that%20would%20be%20even%20better.%20%20Perhaps%20%40brentschmaltz%20can%20help%20with%20that.%22%2C%20%22created_at%22%3A%20%222015-10-06T21%3A26%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-09T16%3A45%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yup%20sure%2C%20i%27ll%20add%20more%20descriptive%20message%20for%20commit%20message.%20%22%2C%20%22created_at%22%3A%20%222015-10-13T18%3A44%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%2C%20%7B%22body%22%3A%20%22Have%20the%20decode%20string%20updated.%20My%20bad.%20%22%2C%20%22created_at%22%3A%20%222015-10-13T18%3A44%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-13T22%3A03%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a2250f8569954757cc6c8960f87d85e055be69b4%20tests/unit/spec/AdalSpec.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23discussion_r41912954%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40weijjia%20The%20old%20test%20strings%20were%20all%20different%20lengths%2C%20but%20these%20are%20all%20the%20same%20length.%20%20Is%20that%20by%20design%3F%20%20%22%2C%20%22created_at%22%3A%20%222015-10-13T19%3A31%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20only%20want%20to%20make%20sure%20if%20the%20padding%20%3D%20or%20%3D%3D%20is%20working.%20%22%2C%20%22created_at%22%3A%20%222015-10-13T19%3A39%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40weijjia%20But%20the%20padding%20is%20directly%20related%20to%20the%20length%20of%20the%20string%20that%20is%20encoded.%20%20I%20think%20it%20would%20be%20best%20to%20match%20those%20things%20up.%22%2C%20%22created_at%22%3A%20%222015-10-13T19%3A50%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40RandalliLama%20it%20makes%20sense.%20updated.%20%22%2C%20%22created_at%22%3A%20%222015-10-13T20%3A15%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/unit/spec/AdalSpec.js%3AL586-612%22%7D%2C%20%22Pull%20f99a7fea96281f9ee847d20b19142d0b2900c2a2%20tests/unit/spec/AdalSpec.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/170%23discussion_r41901881%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20change%20the%20encoded%20string.%20%20This%20one%20is%20on%20the%20edge%20of%20being%20inappropriate.%20%20If%20this%20came%20from%20a%20test%20published%20elsewhere%20we%20should%20update%20that%20test%20as%20well.%22%2C%20%22created_at%22%3A%20%222015-10-13T18%3A02%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/unit/spec/AdalSpec.js%3AL586-612%22%7D%2C%20%22Commit%20f99a7fea96281f9ee847d20b19142d0b2900c2a2%20tests/unit/spec/AdalSpec.js%205%20590%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/commit/f99a7fea96281f9ee847d20b19142d0b2900c2a2%23commitcomment-13747834%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Woah.%20%20Did%20this%20come%20from%20a%20.NET%20test.%20%20I%20would%20be%20more%20comfortable%20with%20a%20different%20encoded%20string.%20%20The%20one%20here%20is%20on%20the%20edge%20of%20being%20inappropriate.%22%2C%20%22created_at%22%3A%20%222015-10-13T18%3A00%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/unit/spec/AdalSpec.js%3AL590%20%28f99a7fe%29%22%7D%2C%20%22Commit%20abc94d6af828fb66c47026e41efb8089e6c7921d%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/commit/abc94d6af828fb66c47026e41efb8089e6c7921d%23commitcomment-13747781%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20the%20future%20you%20could%20expand%20on%20your%20commit%20messages%3F%20%20What%20updates%20to%20the%20decode%20function%20did%20you%20make%20and%20why%3F%22%2C%20%22created_at%22%3A%20%222015-10-13T17%3A58%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22Commit%20abc94d6%20comments%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Commit abc94d6af828fb66c47026e41efb8089e6c7921d'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/commit/abc94d6af828fb66c47026e41efb8089e6c7921d#commitcomment-13747781'>Commit abc94d6 comments</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> In the future you could expand on your commit messages?  What updates to the decode function did you make and why?
- [ ] <a href='#crh-comment-Commit f99a7fea96281f9ee847d20b19142d0b2900c2a2 tests/unit/spec/AdalSpec.js 5 590'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/commit/f99a7fea96281f9ee847d20b19142d0b2900c2a2#commitcomment-13747834'>File: tests/unit/spec/AdalSpec.js:L590 (f99a7fe)</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Woah.  Did this come from a .NET test.  I would be more comfortable with a different encoded string.  The one here is on the edge of being inappropriate.
- [ ] <a href='#crh-comment-Pull f99a7fea96281f9ee847d20b19142d0b2900c2a2 tests/unit/spec/AdalSpec.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/170#discussion_r41901881'>File: tests/unit/spec/AdalSpec.js:L586-612</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Please change the encoded string.  This one is on the edge of being inappropriate.  If this came from a test published elsewhere we should update that test as well.
- [ ] <a href='#crh-comment-Pull a2250f8569954757cc6c8960f87d85e055be69b4 tests/unit/spec/AdalSpec.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/170#discussion_r41912954'>File: tests/unit/spec/AdalSpec.js:L586-612</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @weijjia The old test strings were all different lengths, but these are all the same length.  Is that by design?
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> I only want to make sure if the padding = or == is working.
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @weijjia But the padding is directly related to the length of the string that is encoded.  I think it would be best to match those things up.
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> @RandalliLama it makes sense. updated.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/170#issuecomment-146006898'>General Comment</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Can you add tests for this.  If you can track down existing tests, perhaps from the .NET team, that would be even better.  Perhaps @brentschmaltz can help with that.
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> Yup sure, i'll add more descriptive message for commit message.
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> Have the decode string updated. My bad.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/170?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/170?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/170?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/170'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>