### PR TITLE
add guard clause for `_decodeJwt` method [resubmit to dev branch]

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -872,6 +872,10 @@ AuthenticationContext.prototype._base64DecodeStringUrlSafe = function (base64IdT
 
 // Adal.node js crack function
 AuthenticationContext.prototype._decodeJwt = function (jwtToken) {
+    if (jwtToken === null) {
+      return null;
+    };
+
     var idTokenPartsRegex = /^([^\.\s]*)\.([^\.\s]+)\.([^\.\s]*)$/;
 
     var matches = idTokenPartsRegex.exec(jwtToken);


### PR DESCRIPTION
The purpose is to prevent putting multiple redundant logs.

I'm seeing a lot of same "The returned id_token is not parseable." when I first initialize adal by execute adalAuthenticationServiceProvider.init(...)

<img width="1275" alt="_decodejwt_bug" src="https://cloud.githubusercontent.com/assets/4915433/10373861/417fcd34-6e1a-11e5-8def-d855bcca7d33.png">

After look around into the code, I see that when users are not authenticated yet, the loginResource config is null then it raises the errors when we try to load cached users.

I think it doesn't make sense when we tell that we cannot parse null object so I made this patch to update it.

This patch helped solve my problem. Hope it useful for the others, too!
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/173%23issuecomment-146626743%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/173%23issuecomment-146737008%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/173%23issuecomment-146626743%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40hoang1417__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20This%20seems%20like%20a%20small%20%28but%20important%29%20contribution%2C%20so%20no%20Contribution%20License%20Agreement%20is%20required%20at%20this%20point.%20Real%20humans%20will%20now%20evaluate%20your%20PR.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-08T17%3A11%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40hoang1417%20Thanks%20for%20sending%20the%20PR.%20%22%2C%20%22created_at%22%3A%20%222015-10-09T02%3A07%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/173#issuecomment-146626743'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@hoang1417__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<span>
This seems like a small (but important) contribution, so no Contribution License Agreement is required at this point. Real humans will now evaluate your PR.
</span>
TTYL, MSBOT;
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> @hoang1417 Thanks for sending the PR.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/173?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/173?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/173'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>