### PR TITLE
for intercept call check for host match and add tests

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -783,6 +783,8 @@ AuthenticationContext.prototype.getResourceForEndpoint = function (endpoint) {
         }
     }
     else {
+        // in angular level, the url for $http interceptor call could be relative url, 
+        // if it's relative call, we'll treat it as app backend call. 
         return this.config.loginResource;
     }
     

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -130,9 +130,10 @@ AuthenticationContext = function (config) {
     this._activeRenewals = {};
     this._loginInProgress = false;
     this._renewStates = [];
+
     window.callBackMappedToRenewStates = {};
     window.callBacksMappedToRenewStates = {};
-    
+
     // validate before constructor assignments
     if (config.displayCall && typeof config.displayCall !== 'function') {
         throw new Error('displayCall is not a function');
@@ -775,12 +776,26 @@ AuthenticationContext.prototype.getResourceForEndpoint = function (endpoint) {
     
     // default resource will be clientid if nothing specified
     // App will use idtoken for calls to itself
-    if (endpoint.indexOf(this.config.redirectUri) > -1 || (endpoint.indexOf('http://') !== 0 && endpoint.indexOf('https://') !== 0)) {
+    // check if it's staring from http or https, needs to match with app host
+    if (endpoint.indexOf('http://') > -1 || endpoint.indexOf('https://') > -1) {
+        if (this._getHostFromUri(endpoint) === this._getHostFromUri(this.config.redirectUri)) {
+            return this.config.loginResource;
+        }
+    }
+    else {
         return this.config.loginResource;
     }
     
     // if not the app's own backend or not a domain listed in the endpoints structure
     return null;
+};
+
+AuthenticationContext.prototype._getHostFromUri = function (uri) {
+    // remove http:// or https:// from uri
+    var extractedUri = String(uri).replace(/^(https?:)\/\//, '');
+
+    extractedUri = extractedUri.split('/')[0];
+    return extractedUri;
 };
 
 /*exported  oauth2Callback */
@@ -1168,10 +1183,6 @@ AuthenticationContext.prototype._cloneConfig = function (obj) {
     return copy;
 };
 
-AuthenticationContext.prototype._libVersion = function () {
-    return '1.0.2';
-};
-
 AuthenticationContext.prototype._addClientId = function () {
     // x-client-SKU
     // x-client-Ver
@@ -1207,4 +1218,8 @@ AuthenticationContext.prototype.info = function (message) {
 
 AuthenticationContext.prototype.verbose = function (message) {
     this.log(this.CONSTANTS.LOGGING_LEVEL.VERBOSE, message, null);
+};
+
+AuthenticationContext.prototype._libVersion = function () {
+    return '1.0.7';
 };

--- a/tests/angularModuleSpec.js
+++ b/tests/angularModuleSpec.js
@@ -34,12 +34,11 @@ describe('TaskCtl', function () {
         rootScope = _$rootScope_;
         controller = _$controller_;
         $httpBackend = _$httpBackend_;
-         
+
         //create an empty scope
         scope = rootScope.$new();
         adalServiceProvider.userInfo = { userName: 'UserVerify', isAuthenticated: true };
        
-
         adalServiceProvider.getCachedToken = function (resource) {
             console.log('Requesting token for resource:' + resource);
             if (resource === 'resource1') {

--- a/tests/testApp.js
+++ b/tests/testApp.js
@@ -41,7 +41,7 @@ app.config(['$httpProvider', '$routeProvider', 'adalAuthenticationServiceProvide
             tenant: 'tenantid123',
             clientId: 'clientid123',
             loginResource: 'loginResource123',
-            redirectUri: 'https://myapp.com/',
+            redirectUri: 'https://myapp.com/page',
             endpoints: endpoints  // optional
         },
         $httpProvider   // pass http provider to inject request interceptor to attach tokens

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -606,6 +606,23 @@ describe('Adal', function () {
         }
     });
 
+    it ('test get resource for endpoint from app backend', function () {
+        adal.config.redirectUri = 'https://host.com/page';
+        expect(adal.getResourceForEndpoint('https://host.com')).toBe(adal.config.loginResource);
+        expect(adal.getResourceForEndpoint('https://host.com/a/b')).toBe(adal.config.loginResource);
+        expect(adal.getResourceForEndpoint('https://host.com/page/')).toBe(adal.config.loginResource);
+        expect(adal.getResourceForEndpoint('https://notapp.com/page/')).toBe(null);
+        expect(adal.getResourceForEndpoint('/api/todo')).toBe(adal.config.loginResource);
+    });
+
+    it ('test host extraction', function () {
+        expect(adal._getHostFromUri('https://a.com/b/c')).toBe('a.com');
+        expect(adal._getHostFromUri('http://a.com')).toBe('a.com');
+        expect(adal._getHostFromUri('a.com/b/c')).toBe('a.com');
+        expect(adal._getHostFromUri('http://a.com/')).toBe('a.com');
+        expect(adal._getHostFromUri('http://localhost:8080')).toBe('localhost:8080');
+    });
+
     // TODO angular intercepptor
    
     // TODO angular authenticaitonService


### PR DESCRIPTION
1. For interceptor call, update the  check for backend call -- check if host matches 
2. add tests
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23issuecomment-150435019%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-23T02%3A59%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%3Agun%3A%22%2C%20%22created_at%22%3A%20%222015-10-23T03%3A05%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-23T03%3A21%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20might%20consider%20adding%20a%20comment%20that%20explains%20what%20that%20clause%20is%20about.%5Cr%5CnOtherwise%20I%27m%20signed%20off.%22%2C%20%22created_at%22%3A%20%222015-10-23T03%3A21%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201c7ccc9c261e4703f9f685ea00711186a64de3a6%20lib/adal.js%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23discussion_r42829632%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Under%20what%20circumstances%20do%20we%20end%20up%20here%3F%20%20Getting%20here%20would%20indicate%20that%20this%20is%20not%20an%20http%28s%29%20url.%20%20What%20kind%20of%20non-http%20redirect%20uri%27s%20get%20used%20in%20the%20context%20of%20adal.js%3F%22%2C%20%22created_at%22%3A%20%222015-10-23T03%3A07%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20angular%20interceptor%20call%2C%20developer%20could%20do%20i.e%20%24http.get%28%27/someurl%27%29%2C%20this%20%27/someurl%27%20could%20be%20absolute%20url%20or%20relative%20url.%20If%20it%27s%20relative%2C%20then%20we%20need%20to%20treat%20it%20as%20from%20app%20backend.%20%22%2C%20%22created_at%22%3A%20%222015-10-23T03%3A20%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/adal.js%3AL776-789%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23issuecomment-150435019%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23issuecomment-150438083%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23issuecomment-150447337%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23discussion_r42829632%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23discussion_r42830080%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-js/pull/181%23issuecomment-150447552%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/181#issuecomment-150435019'>General Comment</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> :shipit::gun:
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> You might consider adding a comment that explains what that clause is about.
Otherwise I'm signed off.
- [ ] <a href='#crh-comment-Pull 1c7ccc9c261e4703f9f685ea00711186a64de3a6 lib/adal.js 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/181#discussion_r42829632'>File: lib/adal.js:L776-789</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Under what circumstances do we end up here?  Getting here would indicate that this is not an http(s) url.  What kind of non-http redirect uri's get used in the context of adal.js?
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> In angular interceptor call, developer could do i.e $http.get('/someurl'), this '/someurl' could be absolute url or relative url. If it's relative, then we need to treat it as from app backend.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/181?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/181?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-js/pull/181?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-js/pull/181'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>