### PR TITLE
Redirct Params UI Router

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -120,13 +120,16 @@ if (typeof module !== 'undefined' && module.exports) {
                                         // redirect to login requested page
                                         var loginStartPage = _adal._getItem(_adal.CONSTANTS.STORAGE.START_PAGE);
                                         if (loginStartPage) {
+                                            // Check to see if any params were stored
                                             var paramsJSON = _adal._getItem(_adal.CONSTANTS.STORAGE.START_PAGE_PARAMS); 
                                             
                                             if (paramsJSON) {
+                                                // If params were stored redirect to the page and then 
+                                                // initialize the params
                                                 var loginStartPageParams = JSON.parse(paramsJSON);
-                                                $location.path(loginStartPage).search(loginStartPageParams);
+                                                $location.url(loginStartPage).search(loginStartPageParams);
                                             } else {
-                                                $location.path(loginStartPage);
+                                                $location.url(loginStartPage);
                                             }
                                         }
                                     }, 1);
@@ -163,12 +166,12 @@ if (typeof module !== 'undefined' && module.exports) {
                 };
 
                 var loginHandler = function () {
-                    _adal.info('Login event for:' + $location.$$path);
+                    _adal.info('Login event for:' + $location.$$url);
                     if (_adal.config && _adal.config.localLoginUrl) {
                         $location.path(_adal.config.localLoginUrl);
                     } else {
                         // directly start login flow
-                        _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE, $location.$$path);
+                        _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE, $location.$$url);
                         _adal.info('Start login at:' + window.location.href);
                         $rootScope.$broadcast('adal:loginRedirect');
                         _adal.login();
@@ -182,7 +185,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 var routeChangeHandler = function (e, nextRoute) {
                     if (nextRoute && nextRoute.$$route && isADLoginRequired(nextRoute.$$route, _adal.config)) {
                         if (!_oauthData.isAuthenticated) {
-                            _adal.info('Route change event for:' + $location.$$path);
+                            _adal.info('Route change event for:' + $location.$$url);
                             loginHandler();
                         }
                     }
@@ -191,8 +194,16 @@ if (typeof module !== 'undefined' && module.exports) {
                 var stateChangeHandler = function (e, toState, toParams, fromState, fromParams){
                     if (toState && isADLoginRequired(toState, _adal.config)) {
                         if (!_oauthData.isAuthenticated) {
+                            // $location.$$url is set as the page we are coming from
+                            // Update it so we can store the actual location we want to
+                            // redirect to upon returning
+                            $location.$$url = toState.url;
+                            
+                            // Parameters are not stored in the url on stateChange so
+                            // we store them
                             _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE_PARAMS, JSON.stringify(toParams));
-                            _adal.info('State change event for:' + $location.$$path);
+                            
+                            _adal.info('State change event for:' + $location.$$url);
                             loginHandler();
                         }
                     }

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -120,7 +120,14 @@ if (typeof module !== 'undefined' && module.exports) {
                                         // redirect to login requested page
                                         var loginStartPage = _adal._getItem(_adal.CONSTANTS.STORAGE.START_PAGE);
                                         if (loginStartPage) {
-                                            $location.path(loginStartPage);
+                                            var paramsJSON = _adal._getItem(_adal.CONSTANTS.STORAGE.START_PAGE_PARAMS); 
+                                            
+                                            if (paramsJSON) {
+                                                var loginStartPageParams = JSON.parse(paramsJSON);
+                                                $location.path(loginStartPage).search(loginStartPageParams);
+                                            } else {
+                                                $location.path(loginStartPage);
+                                            }
                                         }
                                     }, 1);
                                     $rootScope.$broadcast('adal:loginSuccess');
@@ -181,9 +188,10 @@ if (typeof module !== 'undefined' && module.exports) {
                     }
                 };
 
-                var stateChangeHandler = function (e, nextRoute) {
-                    if (nextRoute && isADLoginRequired(nextRoute, _adal.config)) {
+                var stateChangeHandler = function (e, toState, toParams, fromState, fromParams){
+                    if (toState && isADLoginRequired(toState, _adal.config)) {
                         if (!_oauthData.isAuthenticated) {
+                            _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE_PARAMS, JSON.stringify(toParams));
                             _adal.info('State change event for:' + $location.$$path);
                             loginHandler();
                         }

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -82,6 +82,7 @@ AuthenticationContext = function (config) {
             ACCESS_TOKEN_KEY: 'adal.access.token.key',
             EXPIRATION_KEY: 'adal.expiration.key',
             START_PAGE: 'adal.start.page',
+            START_PAGE_PARAMS: 'adal.start.page.params',
             FAILED_RENEW: 'adal.failed.renew',
             STATE_LOGIN: 'adal.state.login',
             STATE_RENEW: 'adal.state.renew',

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -435,6 +435,7 @@ AuthenticationContext.prototype.clearCache = function () {
     this._renewStates = [];
     this._saveItem(this.CONSTANTS.STORAGE.STATE_IDTOKEN, '');
     this._saveItem(this.CONSTANTS.STORAGE.START_PAGE, '');
+    this._saveItem(this.CONSTANTS.STORAGE.START_PAGE_PARAMS, '');
     this._saveItem(this.CONSTANTS.STORAGE.USERNAME, '');
     this._saveItem(this.CONSTANTS.STORAGE.IDTOKEN, '');
     this._saveItem(this.CONSTANTS.STORAGE.ERROR, '');


### PR DESCRIPTION
fix: Navigating to private state with route parameters

Every time a user changes states, if they are required to login, we
record the url parameters and save them locally. On return we check to
see if there are any route params and redirect the user appropriately
using them.