### PR TITLE
Added support if iframe and redirect isn't allowed

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -134,11 +134,26 @@ AuthenticationContext = function (config) {
     window.callBackMappedToRenewStates = {};
     window.callBacksMappedToRenewStates = {};
 
+    config.isIframeAllowed = (typeof config.isIframeAllowed != 'undefined') ? config.isIframeAllowed : true;
+    config.isRedirectAllowed = (typeof config.isRedirectAllowed != 'undefined') ? config.isRedirectAllowed : true;
+
     // validate before constructor assignments
     if (config.displayCall && typeof config.displayCall !== 'function') {
         throw new Error('displayCall is not a function');
     }
-    
+
+    if (config.logOutCall && typeof config.logOutCall !== 'function') {
+        throw new Error('logOutCall is not a function');
+    }
+
+    if (!config.isIframeAllowed && !config.displayCall) {
+        throw new Error('If iframe is not allowed, the displayCall function is required');
+    }
+
+    if (!config.isRedirectAllowed && !config.logOutCall) {
+        throw new Error('If redirecting is not allowed, the logOutCall function is required');
+    }
+
     if (!config.clientId) {
         throw new Error('clientId is required');
     }
@@ -276,8 +291,7 @@ AuthenticationContext.prototype._renewToken = function (resource, callback) {
         var keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
         this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + resource + this.CONSTANTS.RESOURCE_DELIMETER);
     }
-    
-    var frameHandle = this._addAdalFrame('adalRenewFrame' + resource);
+
     var expectedState = this._guid() + '|' + resource;
     this._idTokenNonce = this._guid();
     this.config.state = expectedState;
@@ -300,8 +314,15 @@ AuthenticationContext.prototype._renewToken = function (resource, callback) {
     this.idTokenNonce = null;
     this.verbose('Navigate to:' + urlNavigate);
     this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, '');
-    frameHandle.src = 'about:blank';
-    this._loadFrame(urlNavigate, 'adalRenewFrame' + resource);
+
+    if (this.config.isIframeAllowed) {
+        var frameHandle = this._addAdalFrame('adalRenewFrame' + resource);
+        frameHandle.src = 'about:blank';
+        this._loadFrame(urlNavigate, 'adalRenewFrame' + resource);
+    } else {
+        // User defined way of handling the navigation
+        this.config.displayCall(urlNavigate);
+    }
 };
 
 AuthenticationContext.prototype._renewIdToken = function (callback) {
@@ -311,8 +332,7 @@ AuthenticationContext.prototype._renewIdToken = function (callback) {
         var keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
         this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + this.config.clientId + this.CONSTANTS.RESOURCE_DELIMETER);
     }
-    
-    var frameHandle = this._addAdalFrame('adalIdTokenFrame');
+
     var expectedState = this._guid() + '|' + this.config.clientId;
     this._idTokenNonce = this._guid();
     this._saveItem(this.CONSTANTS.STORAGE.NONCE_IDTOKEN, this._idTokenNonce);
@@ -335,8 +355,15 @@ AuthenticationContext.prototype._renewIdToken = function (callback) {
     this.idTokenNonce = null;
     this.verbose('Navigate to:' + urlNavigate);
     this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, '');
-    frameHandle.src = 'about:blank';
-    this._loadFrame(urlNavigate, 'adalIdTokenFrame');
+
+    if (this.config.isIframeAllowed) {
+        var frameHandle = this._addAdalFrame('adalRenewFrame' + resource);
+        frameHandle.src = 'about:blank';
+        this._loadFrame(urlNavigate, 'adalRenewFrame' + resource);
+    } else {
+        // User defined way of handling the navigation
+        this.config.displayCall(urlNavigate);
+    }
 };
 
 AuthenticationContext.prototype._urlContainsQueryStringParameter = function (name, url) {
@@ -488,7 +515,12 @@ AuthenticationContext.prototype.logOut = function () {
     
     var urlNavigate = this.instance + tenant + '/oauth2/logout?' + logout;
     this.info('Logout navigate to: ' + urlNavigate);
-    this.promptUser(urlNavigate);
+    if (!this.config.isRedirectAllowed) {
+        // User defined way of handling the navigation
+        this.config.logOutCall(urlNavigate);
+    } else {
+        this.promptUser(urlNavigate);
+    }
 };
 
 AuthenticationContext.prototype._isEmpty = function (str) {
@@ -801,10 +833,10 @@ AuthenticationContext.prototype._getHostFromUri = function (uri) {
 };
 
 /*exported  oauth2Callback */
-AuthenticationContext.prototype.handleWindowCallback = function () {
+AuthenticationContext.prototype.handleWindowCallback = function (hash) {
     // This is for regular javascript usage for redirect handling
     // need to make sure this is for callback
-    var hash = window.location.hash;
+    hash = hash || window.location.hash;
     if (this.isCallback(hash)) {
         var requestInfo = this.getRequestInfo(hash);
         this.info('Returned from redirect url');
@@ -822,8 +854,10 @@ AuthenticationContext.prototype.handleWindowCallback = function () {
             callback = this.callback;
         }
         
-        window.location.hash = '';
-        window.location = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
+        if (this.config.isRedirectAllowed) {
+            window.location.hash = '';
+            window.location = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
+        }
         if (requestInfo.requestType === this.REQUEST_TYPE.RENEW_TOKEN) {
             callback(this._getItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN] || requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
             return;


### PR DESCRIPTION
There are cases when developing with adaljs where the use of iframes,
redirecting to another page or even changing the the window.location
object is not allowed, for example when developing a google chrome
extension and using the adaljs library.

By adding some extra properties to the initial configuration, the
developer would be able to specify whether the use of iframes and/or
redirect is allowed, as well as a logOutCall function in case the
environment doesn’t allow modifications on the window.location object.
