### PR TITLE
prevent login loop when using directives that make http calls to prot…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,22 @@ Install grunt; call
 Below you can find a quick reference for the most common operations you need to perform to use adal js.
 
 1- Include references to angular.js libraries, adal.js, adal-angular.js in your main app page.
+
 2- include a reference to adal module
 ```js
 var app = angular.module('demoApp', ['ngRoute', 'AdalAngular']);
 ```
-3- Initialize adal with the AAD app coordinates at app config time
+3- ***When HTML5 mode is configured***, ensure the $locationProvider hashPrefix is set
+```js
+	// using '!' as the hashPrefix but can be a character of your choosing
+	app.config(['$locationProvider', function($locationProvider) {
+		$locationProvider.html5Mode(true).hashPrefix('!');
+	}]);
+```
+
+Without the hashPrefix set, the AAD login will loop indefinitely as the callback URL from AAD (in the form of, {yourBaseUrl}/#{AADTokenAndState}) will be rewritten to remove the '#' causing the token parsing to fail and login sequence to occur again.
+
+4- Initialize adal with the AAD app coordinates at app config time
 ```js
 // endpoint to resource mapping(optional)
     var endpoints = {
@@ -80,7 +91,7 @@ adalAuthenticationServiceProvider.init(
         $httpProvider   // pass http provider to inject request interceptor to attach tokens
         );
 ```
-4- Define which routes you want to secure via adal - by adding `requireADLogin: true` to their definition
+5- Define which routes you want to secure via adal - by adding `requireADLogin: true` to their definition
 ```js
 $routeProvider.
     when("/todoList", {
@@ -90,10 +101,10 @@ $routeProvider.
     });
 
 ```
-5- Any service invocation code you might have will remain unchanged. Adal's interceptor will automatically add tokens for every outgoing call. 
+6- Any service invocation code you might have will remain unchanged. Adal's interceptor will automatically add tokens for every outgoing call. 
 
 ***Optional***
-6- If you so choose, in addition (or substitution) to route level protection you can add explicit login/logout UX elements. Furthermore, you can access properties of the currently signed in user directly form JavaScript (via userInfo and userInfo.profile):
+7- If you so choose, in addition (or substitution) to route level protection you can add explicit login/logout UX elements. Furthermore, you can access properties of the currently signed in user directly form JavaScript (via userInfo and userInfo.profile):
 ```html
 <!DOCTYPE html>
 <html>

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -263,49 +263,9 @@ if (typeof module !== 'undefined' && module.exports) {
                 };
             }];
         });
-
-        AdalModule.factory('HttpAuthenticationBuffer', ['$q', '$injector', function ($q, $injector) {
-            var _requestBuffer = [];
-            var $http;
-
-            return {
-                bufferRequest: function (response) {
-                    var defer = $q.defer();
-                    _requestBuffer.push({
-                        response: response,
-                        defer: defer
-                    });
-                    return defer.promise;
-                },
-                flushRequestBuffer: function (error) {
-                    var bufferedRequest;
-                    $http = $http || $injector.get('$http');
-
-                    while (bufferedRequest = _requestBuffer.shift()) {
-                        (function () {
-                            var defer = bufferedRequest.defer;
-                            if (error) {
-                                defer.reject(error);
-                            } else {
-                                $http(bufferedRequest.response.config).then(function (data) {
-                                    defer.resolve(data);
-                                }, function (error) {
-                                    defer.reject(error);
-                                });
-                            }
-                        })();
-                    }
-                }
-            }
-        }]);
-
+        
         // Interceptor for http if needed
-<<<<<<< HEAD
-        AdalModule.factory('ProtectedResourceInterceptor', ['adalAuthenticationService', '$q', '$rootScope', function (authService, $q, $rootScope) {
-=======
-        AdalModule.factory('ProtectedResourceInterceptor', ['adalAuthenticationService', 'HttpAuthenticationBuffer', '$q', '$rootScope', '$window', '$interval', function (authService, httpAuthenticationBuffer, $q, $rootScope, $window, $interval) {
->>>>>>> 8a2131e0cdef27506ecd3629c6da1510ddf32f70
-
+        AdalModule.factory('ProtectedResourceInterceptor', ['adalAuthenticationService', '$q', '$rootScope', '$window', function (authService, $q, $rootScope, $window) {
             return {
                 request: function (config) {
                     if (config) {
@@ -355,22 +315,9 @@ if (typeof module !== 'undefined' && module.exports) {
                 },
                 responseError: function (rejection) {
                     if (rejection && rejection.status === 401) {
-<<<<<<< HEAD
                         var resource = authService.getResourceForEndpoint(rejection.config.url);
                         authService.clearCacheForResource(resource);
                         $rootScope.$broadcast('adal:notAuthorized', rejection, resource);
-=======
-						var resource = authService.getResourceForEndpoint(rejection.config.url);
-						
-						if(!authService.loginInProgress($window.location.hash)) {
-							if (authService.acquiringIdToken()) {
-                                return httpAuthenticationBuffer.bufferRequest(rejection);
-                            }
-                            
-                            authService.clearCacheForResource(resource);
-                            $rootScope.$broadcast('adal:notAuthorized', rejection, resource);
-						}
->>>>>>> 8a2131e0cdef27506ecd3629c6da1510ddf32f70
                     }
 
                     return $q.reject(rejection);

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -287,8 +287,8 @@ if (typeof module !== 'undefined' && module.exports) {
                                 }
                             }
                                 
-                            // Cancel request if login is starting
-                            if (authService.loginInProgress()) {
+                            // Cancel request if login is starting or if within an ADAL frame (to prevent recursive spawning of adal frames. We don't need to load the app completely in the iframe)
+                            if (authService.loginInProgress() || ($window.self.frameElement && /^adal\w+Frame/i.test($window.self.frameElement.id))) {
                                 return $q.reject();
                             } else if (authService.config && isEndpoint) {
                                 // external endpoints

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -206,9 +206,8 @@ if (typeof module !== 'undefined' && module.exports) {
                     login: function () {
                         _adal.login();
                     },
-                    loginInProgress: function (hash) {
-						hash = hash || '';
-                        return _adal.loginInProgress() || _adal.isCallback(hash);
+                    loginInProgress: function () {
+                        return _adal.loginInProgress();
                     },
                     logOut: function () {
                         _adal.logOut();
@@ -259,7 +258,7 @@ if (typeof module !== 'undefined' && module.exports) {
         });
 
         // Interceptor for http if needed
-        AdalModule.factory('ProtectedResourceInterceptor', ['adalAuthenticationService', '$q', '$rootScope', '$window', '$interval', function (authService, $q, $rootScope, $window, $interval) {
+        AdalModule.factory('ProtectedResourceInterceptor', ['adalAuthenticationService', '$q', '$rootScope', function (authService, $q, $rootScope) {
 
             return {
                 request: function (config) {
@@ -310,26 +309,7 @@ if (typeof module !== 'undefined' && module.exports) {
                 },
                 responseError: function (rejection) {
                     if (rejection && rejection.status === 401) {
-						var resource = authService.getResourceForEndpoint(rejection.config.url);
-						
-						if(authService.loginInProgress($window.location.hash)) {
-							var defer = $q.defer();
-							var maxIterations = 20;
-							var canceller = $interval(function() {
-								if(!authService.loginInProgress($window.location.hash)) {
-									$interval.cancel(canceller);
-									defer.resolve(rejection.config);
-								} else if(!maxIterations) {
-									$interval.cancel(canceller);
-									$rootScope.$broadcast('adal:notAuthorized', rejection, resource);
-									defer.reject(rejection);
-								}
-								maxIterations--;
-							}, 100);
-							
-							return defer.promise;
-						}
-						                        
+                        var resource = authService.getResourceForEndpoint(rejection.config.url);
                         authService.clearCacheForResource(resource);
                         $rootScope.$broadcast('adal:notAuthorized', rejection, resource);
                     }

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -206,8 +206,9 @@ if (typeof module !== 'undefined' && module.exports) {
                     login: function () {
                         _adal.login();
                     },
-                    loginInProgress: function () {
-                        return _adal.loginInProgress();
+                    loginInProgress: function (hash) {
+						hash = hash || '';
+                        return _adal.loginInProgress() || _adal.isCallback(hash);
                     },
                     logOut: function () {
                         _adal.logOut();
@@ -258,7 +259,7 @@ if (typeof module !== 'undefined' && module.exports) {
         });
 
         // Interceptor for http if needed
-        AdalModule.factory('ProtectedResourceInterceptor', ['adalAuthenticationService', '$q', '$rootScope', function (authService, $q, $rootScope) {
+        AdalModule.factory('ProtectedResourceInterceptor', ['adalAuthenticationService', '$q', '$rootScope', '$window', '$interval', function (authService, $q, $rootScope, $window, $interval) {
 
             return {
                 request: function (config) {
@@ -309,7 +310,26 @@ if (typeof module !== 'undefined' && module.exports) {
                 },
                 responseError: function (rejection) {
                     if (rejection && rejection.status === 401) {
-                        var resource = authService.getResourceForEndpoint(rejection.config.url);
+						var resource = authService.getResourceForEndpoint(rejection.config.url);
+						
+						if(authService.loginInProgress($window.location.hash)) {
+							var defer = $q.defer();
+							var maxIterations = 20;
+							var canceller = $interval(function() {
+								if(!authService.loginInProgress($window.location.hash)) {
+									$interval.cancel(canceller);
+									defer.resolve(rejection.config);
+								} else if(!maxIterations) {
+									$interval.cancel(canceller);
+									$rootScope.$broadcast('adal:notAuthorized', rejection, resource);
+									defer.reject(rejection);
+								}
+								maxIterations--;
+							}, 100);
+							
+							return defer.promise;
+						}
+						                        
                         authService.clearCacheForResource(resource);
                         $rootScope.$broadcast('adal:notAuthorized', rejection, resource);
                     }


### PR DESCRIPTION
…ected resource before adal login is initiated

A login loop condition occurs when using directives that
make HTTP calls to the ADAL protected API. The HTTP
request from the directive is made prior to ADAL initialization
so the call does not get cancelled in the request interceptor
as a login is not in progress yet. 

The ADAL login then starts
and completes caching the token. Now the directive HTTP
request returns to the response interceptor with a 401. This
triggers a token cache clearing for the resource and another
login begins with the next HTTP request in the app.