### PR TITLE
Fix for the issue #195 - Token renew only works if endpoints are pass…

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -300,27 +300,17 @@ if (typeof module !== 'undefined' && module.exports) {
                         }
 
                         var tokenStored = authService.getCachedToken(resource);
-                        var isEndpoint = false;
                         if (tokenStored) {
                             authService.info('Token is avaliable for this url ' + config.url);
                             // check endpoint mapping if provided
                             config.headers.Authorization = 'Bearer ' + tokenStored;
                             return config;
                         } else {
-
-                            if (authService.config) {
-                                for (var endpointUrl in authService.config.endpoints) {
-                                    if (config.url.indexOf(endpointUrl) > -1) {
-                                        isEndpoint = true;
-                                    }
-                                }
-                            }
-
                             // Cancel request if login is starting
                             if (authService.loginInProgress()) {
                                 authService.info('login already start.');
                                 return $q.reject();
-                            } else if (authService.config && (!authService.config.endpoints || isEndpoint)) {
+                            } else {
                                 // external endpoints
                                 // delayed request to return after iframe completes
                                 var delayedRequest = $q.defer();

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -320,7 +320,7 @@ if (typeof module !== 'undefined' && module.exports) {
                             if (authService.loginInProgress()) {
                                 authService.info('login already start.');
                                 return $q.reject();
-                            } else if (authService.config && isEndpoint) {
+                            } else if (authService.config && (!authService.config.endpoints || isEndpoint)) {
                                 // external endpoints
                                 // delayed request to return after iframe completes
                                 var delayedRequest = $q.defer();


### PR DESCRIPTION
This fix addresses the issue #195.  When the endpoints are not provided, the renew call was not issued.  This change set fixes that check.