### PR TITLE
js: Add optional "version" parameter to config

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -846,8 +846,13 @@ AuthenticationContext.prototype._getNavigateUrl = function (responseType, resour
     if (this.config.instance) {
         this.instance = this.config.instance;
     }
+	    
+    var version = '';
+    if (this.config.version) {
+        version = this.config.version + '/';
+    }
     
-    var urlNavigate = this.instance + tenant + '/oauth2/authorize' + this._serialize(responseType, this.config, resource) + this._addClientId();
+    var urlNavigate = this.instance + tenant + '/oauth2/' + version + 'authorize' + this._serialize(responseType, this.config, resource) + this._addClientId();
     this.info('Navigate url:' + urlNavigate);
     return urlNavigate;
 };

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -156,7 +156,22 @@ describe('Adal', function () {
             + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addClientId() + '&nonce=33333333-3333-4333-b333-333333333333');
         expect(adal.config.state).toBe('33333333-3333-4333-b333-333333333333');
     });
-
+    
+    it('injects version into authorize URL', function () {
+        storageFake.setItem(adal.CONSTANTS.STORAGE.USERNAME, 'test user');
+        adal.config.displayCall = null;
+        adal.config.clientId = 'client';
+        adal.config.redirectUri = 'contoso_site';
+        adal.config.version = 'v2.0';
+        spyOn(adal, 'promptUser');
+        console.log('instance:' + adal.instance);
+        adal.login();
+        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/v2.0/authorize?response_type=id_token&client_id=client&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
+            + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addClientId() + '&nonce=33333333-3333-4333-b333-333333333333');
+        expect(adal.config.state).toBe('33333333-3333-4333-b333-333333333333');
+        adal.config.version = null;
+    });
+    
     it('sets loginprogress to true for login', function () {
         storageFake.setItem(adal.CONSTANTS.STORAGE.USERNAME, 'test user');
         adal.config.displayCall = null;


### PR DESCRIPTION
AAD B2C requires "v2.0" in the authorization endpoint. There has not
been a way to make ADAL JS generate a login URL like
".../oauth2/v2.0/authorize...".

This commit adds an optional parameter "version" to the config object.
If it is set, it is injected in the login URL. If it is not set,
the behavior does not change to previous versions.

This is not full support for AAD B2C. However, it would be very
helpful until full support for AAD B2C comes for ADAL JS.