### PR TITLE
fixes refresh token loop, add anonymousEndpoints extensibility.

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -1,5 +1,5 @@
 ﻿//----------------------------------------------------------------------
-// AdalJS v1.0.9
+// AdalJS v1.0.9.1
 // @preserve Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
 // Apache License 2.0
@@ -89,7 +89,6 @@ if (typeof module !== 'undefined' && module.exports) {
                         }
 
                         if (requestInfo.requestType !== _adal.REQUEST_TYPE.LOGIN) {
-                            _adal._renewActive = false;
                             _adal.callback = $window.parent.AuthenticationContext().callback;
                             if (requestInfo.requestType === _adal.REQUEST_TYPE.RENEW_TOKEN) {
                                 _adal.callback = $window.parent.callBackMappedToRenewStates[requestInfo.stateResponse];
@@ -107,6 +106,10 @@ if (typeof module !== 'undefined' && module.exports) {
                                         return;
                                     } else if (requestInfo.parameters['id_token']) {
                                         _adal.callback(_adal._getItem(_adal.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters['id_token']);
+                                        return;
+                                    } else if (requestInfo.parameters['error']) {
+                                        _adal.callback(_adal._getItem(_adal.CONSTANTS.STORAGE.ERROR_DESCRIPTION), null);
+                                        _adal._renewFailed = true;
                                         return;
                                     }
                                 }
@@ -147,10 +150,11 @@ if (typeof module !== 'undefined' && module.exports) {
                         // No callback. App resumes after closing or moving to new page.
                         // Check token and username
                         updateDataFromCache(_adal.config.loginResource);
-                        if (!_adal._renewActive && !_oauthData.isAuthenticated && _oauthData.userName) {
+                        if (!_oauthData.isAuthenticated && _oauthData.userName && !_adal._renewActive && !_adal._renewFailed) {
                             // Idtoken is expired or not present
                             _adal._renewActive = true;
                             _adal.acquireToken(_adal.config.loginResource, function (error, tokenOut) {
+                                _adal._renewActive = false;
                                 if (error) {
                                     $rootScope.$broadcast('adal:loginFailure', 'auto renew failure');
                                 } else {
@@ -300,6 +304,7 @@ if (typeof module !== 'undefined' && module.exports) {
                         config.headers = config.headers || {};
 
                         var resource = authService.getResourceForEndpoint(config.url);
+                        authService.verbose('Url: ' + config.url + ' maps to resource: ' + resource);
                         if (resource === null) {
                             return config;
                         }

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1,5 +1,5 @@
 ﻿//----------------------------------------------------------------------
-// AdalJS v1.0.9
+// AdalJS v1.0.9.1
 // @preserve Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
 // Apache License 2.0
@@ -173,6 +173,7 @@ AuthenticationContext.prototype.login = function () {
     this._saveItem(this.CONSTANTS.STORAGE.NONCE_IDTOKEN, this._idTokenNonce);
     this._saveItem(this.CONSTANTS.STORAGE.ERROR, '');
     this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, '');
+
 
     var urlNavigate = this._getNavigateUrl('id_token', null) + '&nonce=' + encodeURIComponent(this._idTokenNonce);
     this.frameCallInProgress = false;
@@ -677,6 +678,7 @@ AuthenticationContext.prototype.saveTokenFromHash = function (requestInfo) {
             if (requestInfo.parameters.hasOwnProperty(this.CONSTANTS.ACCESS_TOKEN)) {
                 this.info('Fragment has access token');
                 resource = this._getResourceFromState(requestInfo.stateResponse);
+
                 if (!this._hasResource(resource)) {
                     keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
                     this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + resource + this.CONSTANTS.RESOURCE_DELIMETER);
@@ -738,9 +740,18 @@ AuthenticationContext.prototype.getResourceForEndpoint = function (endpoint) {
             return this.config.loginResource;
         }
     }
-    // in angular level, the url for $http interceptor call could be relative url, 
-    // if it's relative call, we'll treat it as app backend call. 
+    // in angular level, the url for $http interceptor call could be relative url,
+    // if it's relative call, we'll treat it as app backend call.
     else {
+        // if user specified list of anonymous endpoints, no need to send token to these endpoints, return null.
+        if (this.config && this.config.anonymousEndpoints) {
+            for (var i = 0; i < this.config.anonymousEndpoints.length; i++) {
+                if (endpoint.indexOf(this.config.anonymousEndpoints[i]) > -1) {
+                    return null;
+                }
+            }
+        }
+        // all other app's backend calls are secured.
         return this.config.loginResource;
     }
 


### PR DESCRIPTION
#266 #261 #127 : These issues are caused because we secure all the requests send to app's backend. Now, I added an extensibility point - anonymousEndpoints that users can specify in init configuration. Adal will not try to attach tokens to requests send to these endpoints.

#264 #202 #216 : These issues are caused when access token is expired and AAD cookie is not good. So, when adal tries to renew the token, AAD sends an error back to ADAL, these forces adal to go in a loop. Now, I set a `_renewFailed` flag to true if this happens and avoid subsequent token renewal requests when we received an error from AAD.

#260: Earlier, when AAD sends error in response, we were not calling the callback registered by the user at the time of calling the `acquireToken` method. The callback is called with the error.