### PR TITLE
Bug fixes for 1.0.11

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -125,31 +125,7 @@
                                         // redirect to login requested page
                                         var loginStartPage = _adal._getItem(_adal.CONSTANTS.STORAGE.START_PAGE);
                                         if (loginStartPage) {
-                                            // Check to see if any params were stored
-                                            var paramsJSON = _adal._getItem(_adal.CONSTANTS.STORAGE.START_PAGE_PARAMS);
-                                            if (paramsJSON) {
-                                                // If params were stored redirect to the page and then 
-                                                // initialize the params
-                                                var loginStartPageParams = JSON.parse(paramsJSON);
-                                                for (var param in loginStartPageParams) {
-                                                    var searchStr = ":" + param;
-                                                    // replace all optional parameters first
-                                                    if (loginStartPage.indexOf(searchStr) > -1) {
-                                                        loginStartPage = loginStartPage.replace(searchStr, loginStartPageParams[param]);
-                                                        delete loginStartPageParams[param];     // delete the replaced parameters, otherwise .search() method will include these as query parameters too
-                                                    }
-                                                    else {
-                                                        var querySearchStr1 = "?" + param;
-                                                        var querySearchStr2 = "&" + param;
-                                                        if (loginStartPage.indexOf(querySearchStr1) == -1 && loginStartPage.indexOf(querySearchStr2) == -1) {
-                                                            delete loginStartPageParams[param];     // delete the non-url parameters, otherwise .search() method will include these as query parameters too
-                                                        }
-                                                    }
-                                                }
-                                                $location.url(loginStartPage).search(loginStartPageParams);
-                                            } else {
-                                                $location.url(loginStartPage);
-                                            }
+                                            $location.url(loginStartPage);
                                         }
                                     }, 1);
                                     $rootScope.$broadcast('adal:loginSuccess');
@@ -236,15 +212,6 @@
                     if (toState) {
                         if (isADLoginRequired(toState, _adal.config)) {
                             if (!_oauthData.isAuthenticated && !_adal._renewActive) {
-                                // $location.$$url is set as the page we are coming from
-                                // Update it so we can store the actual location we want to
-                                // redirect to upon returning
-                                $location.$$url = toState.url; //.href(toState, toParams, { absolute: true });
-
-                                // Parameters are not stored in the url on stateChange so
-                                // we store them
-                                _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE_PARAMS, JSON.stringify(toParams));
-
                                 _adal.info('State change event for:' + $location.$$url);
                                 loginHandler();
                             }
@@ -271,7 +238,7 @@
                     // public methods will be here that are accessible from Controller
                     config: _adal.config,
                     login: function () {
-                        _adal.login();
+                        loginHandler();
                     },
                     loginInProgress: function () {
                         return _adal.loginInProgress();

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -330,6 +330,7 @@
                             // Cancel request if login is starting
                             if (authService.loginInProgress()) {
                                 authService.info('login is in progress.');
+                                config.data = 'login in progress, cancelling the request';
                                 return $q.reject(config);
                             }
                             else if (authService.userInfo.loginError) {

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -83,11 +83,8 @@
                         var requestInfo = _adal.getRequestInfo(hash);
                         _adal.saveTokenFromHash(requestInfo);
 
-                        if ($location.$$html5) {
-                            $window.location = $window.location.origin + $window.location.pathname;
-                        } else {
-                            $location.hash('');
-                        }
+                        // resetting hash to remove fragments sent by AAD
+                        $location.hash('');
 
                         if (requestInfo.requestType !== _adal.REQUEST_TYPE.LOGIN) {
                             _adal.callback = $window.parent.AuthenticationContext().callback;

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -131,6 +131,21 @@
                                                 // If params were stored redirect to the page and then 
                                                 // initialize the params
                                                 var loginStartPageParams = JSON.parse(paramsJSON);
+                                                for (var param in loginStartPageParams) {
+                                                    var searchStr = ":" + param;
+                                                    // replace all optional parameters first
+                                                    if (loginStartPage.indexOf(searchStr) > -1) {
+                                                        loginStartPage = loginStartPage.replace(searchStr, loginStartPageParams[param]);
+                                                        delete loginStartPageParams[param];     // delete the replaced parameters, otherwise .search() method will include these as query parameters too
+                                                    }
+                                                    else {
+                                                        var querySearchStr1 = "?" + param;
+                                                        var querySearchStr2 = "&" + param;
+                                                        if (loginStartPage.indexOf(querySearchStr1) == -1 && loginStartPage.indexOf(querySearchStr2) == -1) {
+                                                            delete loginStartPageParams[param];     // delete the non-url parameters, otherwise .search() method will include these as query parameters too
+                                                        }
+                                                    }
+                                                }
                                                 $location.url(loginStartPage).search(loginStartPageParams);
                                             } else {
                                                 $location.url(loginStartPage);
@@ -224,7 +239,7 @@
                                 // $location.$$url is set as the page we are coming from
                                 // Update it so we can store the actual location we want to
                                 // redirect to upon returning
-                                $location.$$url = toState.url;
+                                $location.$$url = toState.url; //.href(toState, toParams, { absolute: true });
 
                                 // Parameters are not stored in the url on stateChange so
                                 // we store them

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -74,7 +74,7 @@
             // $rootScope, $window, $q, $location, $timeout are injected by Angular
             this.$get = ['$rootScope', '$window', '$q', '$location', '$timeout', function ($rootScope, $window, $q, $location, $timeout) {
 
-                var locationChangeHandler = function (event, newUrl, oldUrl) {
+                var locationChangeHandler = function (event) {
                     var hash = $window.location.hash;
 
                     if (_adal.isCallback(hash)) {

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -74,7 +74,7 @@
             // $rootScope, $window, $q, $location, $timeout are injected by Angular
             this.$get = ['$rootScope', '$window', '$q', '$location', '$timeout', function ($rootScope, $window, $q, $location, $timeout) {
 
-                var locationChangeHandler = function () {
+                var locationChangeHandler = function (event, newUrl, oldUrl) {
                     var hash = $window.location.hash;
 
                     if (_adal.isCallback(hash)) {
@@ -86,7 +86,7 @@
                         if ($location.$$html5) {
                             $window.location = $window.location.origin + $window.location.pathname;
                         } else {
-                            $window.location.hash = '';
+                            $location.hash('');
                         }
 
                         if (requestInfo.requestType !== _adal.REQUEST_TYPE.LOGIN) {
@@ -99,6 +99,9 @@
                         // Return to callback if it is send from iframe
                         if (requestInfo.stateMatch) {
                             if (typeof _adal.callback === 'function') {
+                                // since this is a token renewal request in iFrame, we don't need to proceed with the location change.
+                                event.preventDefault();
+
                                 // Call within the same context without full page redirect keeps the callback
                                 if (requestInfo.requestType === _adal.REQUEST_TYPE.RENEW_TOKEN) {
                                     // Idtoken or Accestoken can be renewed
@@ -168,7 +171,8 @@
                     _adal.info('Login event for:' + $location.$$url);
                     if (_adal.config && _adal.config.localLoginUrl) {
                         $location.path(_adal.config.localLoginUrl);
-                    } else {
+                    }
+                    else {
                         // directly start login flow
                         _adal._saveItem(_adal.CONSTANTS.STORAGE.START_PAGE, $location.$$url);
                         _adal.info('Start login at:' + window.location.href);
@@ -195,7 +199,7 @@
                 var routeChangeHandler = function (e, nextRoute) {
                     if (nextRoute && nextRoute.$$route) {
                         if (isADLoginRequired(nextRoute.$$route, _adal.config)) {
-                            if (!_oauthData.isAuthenticated && !_adal._renewActive) {
+                            if (!_oauthData.isAuthenticated && !_adal._renewActive && !_oauthData.loginError) {
                                 _adal.info('Route change event for:' + $location.$$url);
                                 loginHandler();
                             }
@@ -211,7 +215,7 @@
                 var stateChangeHandler = function (e, toState, toParams, fromState, fromParams) {
                     if (toState) {
                         if (isADLoginRequired(toState, _adal.config)) {
-                            if (!_oauthData.isAuthenticated && !_adal._renewActive) {
+                            if (!_oauthData.isAuthenticated && !_adal._renewActive && !_oauthData.loginError) {
                                 _adal.info('State change event for:' + $location.$$url);
                                 loginHandler();
                             }
@@ -310,25 +314,30 @@
                         // Loading with injector is suggested at github. https://github.com/angular/angular.js/issues/2367
 
                         config.headers = config.headers || {};
-
                         var resource = authService.getResourceForEndpoint(config.url);
                         authService.verbose('Url: ' + config.url + ' maps to resource: ' + resource);
                         if (resource === null) {
                             return config;
                         }
-
                         var tokenStored = authService.getCachedToken(resource);
                         if (tokenStored) {
                             authService.info('Token is available for this url ' + config.url);
                             // check endpoint mapping if provided
                             config.headers.Authorization = 'Bearer ' + tokenStored;
                             return config;
-                        } else {
+                        }
+                        else {
                             // Cancel request if login is starting
                             if (authService.loginInProgress()) {
-                                authService.info('login already started.');
-                                return $q.reject('login in progress, cancelling the request');
-                            } else {
+                                authService.info('login is in progress.');
+                                return $q.reject(config);
+                            }
+                            else if (authService.userInfo.loginError) {
+                                authService.info('Error in logging in the user: ' + authService.userInfo.loginError);
+                                config.data = 'Error in logging in the user, cancelling the request. Error: ' + authService.userInfo.loginError;
+                                return $q.reject(config);
+                            }
+                            else {
                                 // delayed request to return after iframe completes
                                 var delayedRequest = $q.defer();
                                 authService.acquireToken(resource).then(function (token) {
@@ -336,7 +345,8 @@
                                     config.headers.Authorization = 'Bearer ' + token;
                                     delayedRequest.resolve(config);
                                 }, function (err) {
-                                    delayedRequest.reject(err);
+                                    config.data = err;
+                                    delayedRequest.reject(config);
                                 });
 
                                 return delayedRequest.promise;
@@ -347,7 +357,7 @@
                     }
                 },
                 responseError: function (rejection) {
-                    authService.info('Getting error in the response');
+                    authService.info('Getting error in the response.');
                     if (rejection) {
                         if (rejection.status === 401) {
                             var resource = authService.getResourceForEndpoint(rejection.config.url);

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1,4 +1,4 @@
-//----------------------------------------------------------------------
+﻿//----------------------------------------------------------------------
 // AdalJS v1.0.10
 // @preserve Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
@@ -148,6 +148,10 @@ var AuthenticationContext = (function () {
 
         this.config = this._cloneConfig(config);
 
+        if (this.config.instance) {
+            this.instance = this.config.instance;
+        }
+
         // App can request idtoken for itself using clientid as resource
         if (!this.config.loginResource) {
             this.config.loginResource = this.config.clientId;
@@ -155,6 +159,10 @@ var AuthenticationContext = (function () {
 
         if (!this.config.redirectUri) {
             this.config.redirectUri = window.location.href;
+        }
+
+        if (!this.config.anonymousEndpoints) {
+            this.config.anonymousEndpoints = [];
         }
     };
 
@@ -221,7 +229,6 @@ var AuthenticationContext = (function () {
             return null;
         }
     };
-
     /**
      * Retrieves and parse idToken from localstorage
      * @returns {User} user object
@@ -255,7 +262,7 @@ var AuthenticationContext = (function () {
         }
     };
 
-    // var errorResponse = {error:'', errorDescription:''};
+    // var errorResponse = {error:'', error_description:''};
     // var token = 'string token';
     // callback(errorResponse, token)
     // with callback
@@ -270,7 +277,6 @@ var AuthenticationContext = (function () {
         this.info('renewToken is called for resource:' + resource);
         var frameHandle = this._addAdalFrame('adalRenewFrame' + resource);
         var expectedState = this._guid() + '|' + resource;
-        this._idTokenNonce = this._guid();
         this.config.state = expectedState;
         // renew happens in iframe, so it keeps javascript context
         this._renewStates.push(expectedState);
@@ -283,10 +289,8 @@ var AuthenticationContext = (function () {
             urlNavigate += '&domain_hint=' + encodeURIComponent(this._getDomainHint());
         }
 
-        urlNavigate += '&nonce=' + encodeURIComponent(this._idTokenNonce);
         this.callback = callback;
         this.registerCallback(expectedState, resource, callback);
-        this.idTokenNonce = null;
         this.verbose('Navigate to:' + urlNavigate);
         this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, '');
         frameHandle.src = 'about:blank';
@@ -449,10 +453,6 @@ var AuthenticationContext = (function () {
         this._user = null;
         if (this.config.tenant) {
             tenant = this.config.tenant;
-        }
-
-        if (this.config.instance) {
-            this.instance = this.config.instance;
         }
 
         if (this.config.postLogoutRedirectUri) {
@@ -662,7 +662,7 @@ var AuthenticationContext = (function () {
 
             if (requestInfo.requestType === this.REQUEST_TYPE.LOGIN) {
                 this._loginInProgress = false;
-                this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, requestInfo.parameters.errorDescription);
+                this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, requestInfo.parameters.error_description);
             }
         } else {
 
@@ -741,8 +741,8 @@ var AuthenticationContext = (function () {
                 return this.config.loginResource;
             }
         }
-            // in angular level, the url for $http interceptor call could be relative url,
-            // if it's relative call, we'll treat it as app backend call.
+        // in angular level, the url for $http interceptor call could be relative url,
+        // if it's relative call, we'll treat it as app backend call.
         else {
             // if user specified list of anonymous endpoints, no need to send token to these endpoints, return null.
             if (this.config && this.config.anonymousEndpoints) {
@@ -801,10 +801,6 @@ var AuthenticationContext = (function () {
         var tenant = 'common';
         if (this.config.tenant) {
             tenant = this.config.tenant;
-        }
-
-        if (this.config.instance) {
-            this.instance = this.config.instance;
         }
 
         var urlNavigate = this.instance + tenant + '/oauth2/authorize' + this._serialize(responseType, this.config, resource) + this._addLibMetadata();
@@ -892,7 +888,7 @@ var AuthenticationContext = (function () {
                 decoded += String.fromCharCode(c1, c2);
                 break;
             }
-                // if last one is '='
+            // if last one is '='
             else if (i + 1 === length - 1) {
                 bits = h1 << 18 | h2 << 12
                 c1 = bits >> 16 & 255;

--- a/tests/angularModuleSpec.js
+++ b/tests/angularModuleSpec.js
@@ -201,11 +201,11 @@ describe('TaskCtl', function () {
 
         rootScope.$on('adal:errorResponse', function (event, message) {
             expect(event.name).toBe('adal:errorResponse');
-            expect(message).toBe('login in progress, cancelling the request');
+            expect(message.data).toBe('login in progress, cancelling the request');
         });
         scope.taskCall5();
         rootScope.$apply();
-        expect(rootScope.$broadcast).toHaveBeenCalledWith('adal:errorResponse', 'login in progress, cancelling the request');
+        expect(rootScope.$broadcast).toHaveBeenCalled();
     });
 
     it('tests stateMismatch broadcast when state does not match', function () {

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -54,7 +54,7 @@ describe('Adal', function () {
         }
     };
     var angularMock = {};
-    var conf = { loginResource: 'default resource', tenant: 'testtenant', clientId: 'e9a5a8b6-8af7-4719-9821-0deef255f68e' };
+    var conf = { loginResource: 'defaultResource', tenant: 'testtenant', clientId: 'e9a5a8b6-8af7-4719-9821-0deef255f68e' };
     var testPage = 'this is a song';
     var STORAGE_PREFIX = 'adal';
     var STORAGE_ACCESS_TOKEN_KEY = STORAGE_PREFIX + '.access.token.key';
@@ -120,8 +120,8 @@ describe('Adal', function () {
 
     it('gets default resource for empty endpoint mapping', function () {
         adal.config.endpoints = null;
-        expect(adal.getResourceForEndpoint('a')).toBe('default resource');
-        expect(adal.getResourceForEndpoint('b')).toBe('default resource');
+        expect(adal.getResourceForEndpoint('a')).toBe('defaultResource');
+        expect(adal.getResourceForEndpoint('b')).toBe('defaultResource');
     });
 
     it('gets null resource for annonymous endpoints', function () {
@@ -129,7 +129,7 @@ describe('Adal', function () {
         expect(adal.getResourceForEndpoint('app/views')).toBe(null);
         expect(adal.getResourceForEndpoint('app/views/abc')).toBe(null);
         expect(adal.getResourceForEndpoint('default/app/views/abc')).toBe(null);
-        expect(adal.getResourceForEndpoint('app/home')).toBe('default resource');
+        expect(adal.getResourceForEndpoint('app/home')).toBe('defaultResource');
     });
 
     it('says token expired', function () {
@@ -156,7 +156,7 @@ describe('Adal', function () {
         spyOn(adal, 'promptUser');
         console.log('instance:' + adal.instance);
         adal.login();
-        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
+        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&resource=defaultResource&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
             + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addLibMetadata() + '&nonce=33333333-3333-4333-b333-333333333333');
         expect(adal.config.state).toBe('33333333-3333-4333-b333-333333333333');
     });
@@ -182,7 +182,7 @@ describe('Adal', function () {
         adal.config.displayCall = displayCallback;
         spyOn(adal.config, 'displayCall');
         adal.login();
-        expect(adal.config.displayCall).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333' 
+        expect(adal.config.displayCall).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&resource=defaultResource&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
             + '&client-request-id=33333333-3333-4333-b333-333333333333'
             + adal._addLibMetadata()
             + '&nonce=33333333-3333-4333-b333-333333333333' 
@@ -237,7 +237,7 @@ describe('Adal', function () {
         runs(function () {
             console.log('Frame src:' + frameMock.src);
             expect(frameMock.src).toBe(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=token&client_id=client&resource=' + RESOURCE1 + '&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333%7Ctoken.resource1'
-                + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addLibMetadata() + '&prompt=none&login_hint=test%40testuser.com&domain_hint=testuser.com&nonce=33333333-3333-4333-b333-333333333333');
+                + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addLibMetadata() + '&prompt=none&login_hint=test%40testuser.com&domain_hint=testuser.com');
         });
         
     });
@@ -274,7 +274,7 @@ describe('Adal', function () {
         runs(function () {
             console.log('Frame src:' + frameMock.src);
             expect(frameMock.src).toBe(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=token&client_id=client&resource=' + RESOURCE1 + '&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333%7Ctoken.resource1'
-                + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addLibMetadata() + '&prompt=none&login_hint=test%40testuser.com&domain_hint=testuser.com&nonce=33333333-3333-4333-b333-333333333333');
+                + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addLibMetadata() + '&prompt=none&login_hint=test%40testuser.com&domain_hint=testuser.com');
         });
         
         //Simulate callback from the frame.

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -156,7 +156,7 @@ describe('Adal', function () {
         spyOn(adal, 'promptUser');
         console.log('instance:' + adal.instance);
         adal.login();
-        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&resource=defaultResource&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
+        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
             + '&client-request-id=33333333-3333-4333-b333-333333333333' + adal._addLibMetadata() + '&nonce=33333333-3333-4333-b333-333333333333');
         expect(adal.config.state).toBe('33333333-3333-4333-b333-333333333333');
     });
@@ -182,7 +182,7 @@ describe('Adal', function () {
         adal.config.displayCall = displayCallback;
         spyOn(adal.config, 'displayCall');
         adal.login();
-        expect(adal.config.displayCall).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&resource=defaultResource&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
+        expect(adal.config.displayCall).toHaveBeenCalledWith(DEFAULT_INSTANCE + conf.tenant + '/oauth2/authorize?response_type=id_token&client_id=client&redirect_uri=contoso_site&state=33333333-3333-4333-b333-333333333333'
             + '&client-request-id=33333333-3333-4333-b333-333333333333'
             + adal._addLibMetadata()
             + '&nonce=33333333-3333-4333-b333-333333333333' 


### PR DESCRIPTION
Multiple bug fixes:
1. #282: initialize anonymousEndpoints with a default value
2. #278: replace login() by loginHandler() so that start page is saved
3. #232 and #130: restore the start page url correctly, so that we do not loose any query string parameters
4. #201: update location hash using $location.hash, and use event.preventDefault when renewing token so browser refresh does not happen.