### PR TITLE
Fix typos, variable refs, and dead comment. fixes #309

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -65,7 +65,7 @@ if (typeof module !== 'undefined' && module.exports) {
                     throw new Error('You must set configOptions, when calling init');
                 }
 
-                // loginresource is used to set authenticated status
+                // loginResource is used to set authenticated status
                 updateDataFromCache(_adal.config.loginResource);
             };
 
@@ -95,12 +95,12 @@ if (typeof module !== 'undefined' && module.exports) {
                             }
                         }
 
-                        // Return to callback if it is send from iframe
+                        // Return to callback if it is sent from iframe
                         if (requestInfo.stateMatch) {
                             if (typeof _adal.callback === 'function') {
                                 // Call within the same context without full page redirect keeps the callback
                                 if (requestInfo.requestType === _adal.REQUEST_TYPE.RENEW_TOKEN) {
-                                    // Idtoken or Accestoken can be renewed
+                                    // id_token or access_token can be renewed
                                     if (requestInfo.parameters['access_token']) {
                                         _adal.callback(_adal._getItem(_adal.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters['access_token']);
                                         return;
@@ -127,7 +127,7 @@ if (typeof module !== 'undefined' && module.exports) {
                                             // Check to see if any params were stored
                                             var paramsJSON = _adal._getItem(_adal.CONSTANTS.STORAGE.START_PAGE_PARAMS);
                                             if (paramsJSON) {
-                                                // If params were stored redirect to the page and then 
+                                                // If params were stored redirect to the page and then
                                                 // initialize the params
                                                 var loginStartPageParams = JSON.parse(paramsJSON);
                                                 $location.url(loginStartPage).search(loginStartPageParams);
@@ -323,9 +323,6 @@ if (typeof module !== 'undefined' && module.exports) {
                 request: function (config) {
                     if (config) {
 
-                        // This interceptor needs to load service, but dependeny definition causes circular reference error.
-                        // Loading with injector is suggested at github. https://github.com/angular/angular.js/issues/2367
-
                         config.headers = config.headers || {};
 
                         var resource = authService.getResourceForEndpoint(config.url);
@@ -336,7 +333,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
                         var tokenStored = authService.getCachedToken(resource);
                         if (tokenStored) {
-                            authService.info('Token is avaliable for this url ' + config.url);
+                            authService.info('Token is available for this url ' + config.url);
                             // check endpoint mapping if provided
                             config.headers.Authorization = 'Bearer ' + tokenStored;
                             return config;
@@ -349,7 +346,7 @@ if (typeof module !== 'undefined' && module.exports) {
                                 // delayed request to return after iframe completes
                                 var delayedRequest = $q.defer();
                                 authService.acquireToken(resource).then(function (token) {
-                                    authService.verbose('Token is avaliable');
+                                    authService.verbose('Token is available');
                                     config.headers.Authorization = 'Bearer ' + token;
                                     delayedRequest.resolve(config);
                                 }, function (err) {


### PR DESCRIPTION
There are a few typos in the comments, some variables that are referred to
that are not matched in casing, and an invalid comment that no longer
applies that make reading the code a bit confusing.

The comment about $injector was removed because it appears it no longer
applies. $injector is not used anymore in the service. There is no
circular dependency issue.

I'm not sure if this PR should be made against master, dev, or release 1.0.11 branch. I'll make it against master for now and can close and reopen if you advise otherwise.