### PR TITLE
update comments in code. fixes #309

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -66,7 +66,7 @@
                     throw new Error('You must set configOptions, when calling init');
                 }
 
-                // loginresource is used to set authenticated status
+                // loginResource is used to set authenticated status
                 updateDataFromCache(_adal.config.loginResource);
             };
 
@@ -93,7 +93,7 @@
                             }
                         }
 
-                        // Return to callback if it is send from iframe
+                        // Return to callback if it is sent from iframe
                         if (requestInfo.stateMatch) {
                             if (typeof _adal.callback === 'function') {
                                 // since this is a token renewal request in iFrame, we don't need to proceed with the location change.
@@ -101,7 +101,7 @@
 
                                 // Call within the same context without full page redirect keeps the callback
                                 if (requestInfo.requestType === _adal.REQUEST_TYPE.RENEW_TOKEN) {
-                                    // Idtoken or Accestoken can be renewed
+                                    // id_token or access_token can be renewed
                                     if (requestInfo.parameters['access_token']) {
                                         _adal.callback(_adal._getItem(_adal.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters['access_token']);
                                         return;
@@ -118,7 +118,7 @@
                                 // normal full login redirect happened on the page
                                 updateDataFromCache(_adal.config.loginResource);
                                 if (_oauthData.userName) {
-                                    //IDtoken is added as token for the app
+                                    // id_token is added as token for the app
                                     $timeout(function () {
                                         updateDataFromCache(_adal.config.loginResource);
                                         $rootScope.userInfo = _oauthData;
@@ -143,7 +143,7 @@
                         // Check token and username
                         updateDataFromCache(_adal.config.loginResource);
                         if (!_oauthData.isAuthenticated && _oauthData.userName && !_adal._renewActive && !_adal._renewFailed) {
-                            // Idtoken is expired or not present
+                            // id_token is expired or not present
                             _adal._renewActive = true;
                             _adal.acquireToken(_adal.config.loginResource, function (error, tokenOut) {
                                 _adal._renewActive = false;
@@ -306,9 +306,6 @@
             return {
                 request: function (config) {
                     if (config) {
-
-                        // This interceptor needs to load service, but dependeny definition causes circular reference error.
-                        // Loading with injector is suggested at github. https://github.com/angular/angular.js/issues/2367
 
                         config.headers = config.headers || {};
                         var resource = authService.getResourceForEndpoint(config.url);


### PR DESCRIPTION
There are a few typos in the comments, some variables that are referred to
that are not matched in casing, and an invalid comment that no longer
applies that make reading the code a bit confusing.

The comment about $injector was removed because it appears it no longer
applies. $injector is not used anymore in the service. There is no
circular dependency issue.