### PR TITLE
fixed authorization header overrides so we can use different kinds of…

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -338,7 +338,9 @@ if (typeof module !== 'undefined' && module.exports) {
                         if (tokenStored) {
                             authService.info('Token is avaliable for this url ' + config.url);
                             // check endpoint mapping if provided
-                            config.headers.Authorization = 'Bearer ' + tokenStored;
+                            if(config.headers.Authorization){
+                                config.headers.Authorization = 'Bearer ' + tokenStored;
+                            }
                             return config;
                         } else {
                             // Cancel request if login is starting
@@ -350,7 +352,9 @@ if (typeof module !== 'undefined' && module.exports) {
                                 var delayedRequest = $q.defer();
                                 authService.acquireToken(resource).then(function (token) {
                                     authService.verbose('Token is avaliable');
-                                    config.headers.Authorization = 'Bearer ' + token;
+                                    if(config.headers.Authorization) {
+                                        config.headers.Authorization = 'Bearer ' + token;
+                                    }
                                     delayedRequest.resolve(config);
                                 }, function (err) {
                                     delayedRequest.reject(err);


### PR DESCRIPTION
This fix makes sure that it will not set the authorization header when  it is already set. Some services (mostly api's) require other authorization headers like "basic"
