### PR TITLE
First implementation of angular2 http and service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .externalToolBuilders
 *.swp
 node_modules
+typings
 *~
 /.c9revisions/
 doc/

--- a/dist/AdalHttp.d.ts
+++ b/dist/AdalHttp.d.ts
@@ -1,0 +1,79 @@
+/// <reference path="../typings/index.d.ts" />
+import { ModuleWithProviders } from '@angular/core';
+import { Http, ConnectionBackend, Request, RequestOptions, RequestOptionsArgs, Response } from '@angular/http';
+import { Observable } from 'rxjs/RX';
+export interface AdalUser {
+    userName: string;
+    profile: any;
+}
+export declare class AuthenticationContext {
+    _renewActive: boolean;
+    constructor(config: AdalConfig);
+    login(): any;
+    getCachedToken(resource: string): string;
+    getCachedUser(): AdalUser;
+    acquireToken(resource: string, callback: (error?: string, token?: string) => void): any;
+    clearCache(): any;
+    clearCacheForResource(resource: string): any;
+    logout(): any;
+    getUser(callback: (error?: string, user?: AdalUser) => void): any;
+    isCallback(hash: string): boolean;
+    getLoginError(): string;
+    getResourceForEndpoint(endpoint: string): string;
+}
+export interface AdalConfig {
+    tenant?: string;
+    clientId?: string;
+    redirectUri?: string;
+    instance?: string;
+    endpoints?: any[];
+}
+export declare class AdalHttp extends Http {
+    protected adal: AdalAuthenticationService;
+    constructor(backend: ConnectionBackend, defaultOptions: RequestOptions, adal: AdalAuthenticationService);
+    protected mergeOptions(url: string | Request, options?: RequestOptionsArgs): Observable<RequestOptionsArgs>;
+    /**
+ * Performs any type of http request. First argument is required, and can either be a url or
+ * a {@link Request} instance. If the first argument is a url, an optional {@link RequestOptions}
+ * object can be provided as the 2nd argument. The options object will be merged with the values
+ * of {@link BaseRequestOptions} before performing the request.
+ */
+    request(url: string | Request, options?: RequestOptionsArgs): Observable<Response>;
+    /**
+     * Performs a request with `get` http method.
+     */
+    get(url: string, options?: RequestOptionsArgs): Observable<Response>;
+    /**
+     * Performs a request with `post` http method.
+     */
+    post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
+    /**
+     * Performs a request with `put` http method.
+     */
+    put(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
+    /**
+     * Performs a request with `delete` http method.
+     */
+    delete(url: string, options?: RequestOptionsArgs): Observable<Response>;
+    /**
+     * Performs a request with `patch` http method.
+     */
+    patch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
+    /**
+     * Performs a request with `head` http method.
+     */
+    head(url: string, options?: RequestOptionsArgs): Observable<Response>;
+}
+export declare class AdalAuthenticationService {
+    protected config: AdalConfig;
+    protected _adal: AuthenticationContext;
+    constructor(config: AdalConfig);
+    logout(): void;
+    getCachedToken(resource: string): string;
+    acquireToken(url: string): Observable<string>;
+    getUser(): Observable<AdalUser>;
+}
+export declare function provideAdalAuth(config?: AdalConfig): any[];
+export declare class AdalModule {
+    static withConfig(config?: AdalConfig): ModuleWithProviders;
+}

--- a/dist/AdalHttp.js
+++ b/dist/AdalHttp.js
@@ -1,0 +1,220 @@
+/// <reference path="../typings/index.d.ts" />
+"use strict";
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var core_1 = require('@angular/core');
+var http_1 = require('@angular/http');
+var RX_1 = require('rxjs/RX');
+'use strict';
+var AdalHttp = (function (_super) {
+    __extends(AdalHttp, _super);
+    function AdalHttp(backend, defaultOptions, adal) {
+        _super.call(this, backend, defaultOptions);
+        this.adal = adal;
+    }
+    AdalHttp.prototype.mergeOptions = function (url, options) {
+        var _this = this;
+        return RX_1.Observable.create(function (observer) {
+            var resourceUrl = (url instanceof http_1.Request) ? url.url : url;
+            _this.adal.acquireToken(resourceUrl)
+                .subscribe(function (token) {
+                // Combine constructor default options with request options
+                var mergedOptions;
+                if (_this._defaultOptions) {
+                    mergedOptions = Object.assign({}, _this._defaultOptions);
+                }
+                else {
+                    mergedOptions = new http_1.RequestOptions();
+                }
+                if (!mergedOptions.headers) {
+                    mergedOptions.headers = new http_1.Headers();
+                }
+                if (options) {
+                    options.headers.forEach(function (values, name, headers) {
+                        mergedOptions.headers.set(name, values);
+                    });
+                    mergedOptions.method = options.method;
+                    mergedOptions.body = options.body;
+                    mergedOptions.search = options.search;
+                }
+                mergedOptions.headers.set('Authorization', "Bearer " + token);
+                observer.next(mergedOptions);
+            }, function (error) {
+                observer.error(error);
+            });
+        });
+    };
+    /**
+ * Performs any type of http request. First argument is required, and can either be a url or
+ * a {@link Request} instance. If the first argument is a url, an optional {@link RequestOptions}
+ * object can be provided as the 2nd argument. The options object will be merged with the values
+ * of {@link BaseRequestOptions} before performing the request.
+ */
+    AdalHttp.prototype.request = function (url, options) {
+        var _this = this;
+        return this.mergeOptions(url, options)
+            .flatMap(function (requestOptions) {
+            if (!requestOptions.body) {
+                requestOptions.body = '';
+            }
+            return _super.prototype.request.call(_this, url, requestOptions);
+        });
+    };
+    /**
+     * Performs a request with `get` http method.
+     */
+    AdalHttp.prototype.get = function (url, options) {
+        var _this = this;
+        return this.mergeOptions(url, options)
+            .flatMap(function (requestOptions) {
+            if (!requestOptions.body) {
+                requestOptions.body = '';
+            }
+            return _super.prototype.get.call(_this, url, requestOptions);
+        });
+    };
+    /**
+     * Performs a request with `post` http method.
+     */
+    AdalHttp.prototype.post = function (url, body, options) {
+        var _this = this;
+        return this.mergeOptions(url, options)
+            .flatMap(function (requestOptions) {
+            return _super.prototype.post.call(_this, url, body, requestOptions);
+        });
+    };
+    /**
+     * Performs a request with `put` http method.
+     */
+    AdalHttp.prototype.put = function (url, body, options) {
+        var _this = this;
+        return this.mergeOptions(url, options)
+            .flatMap(function (requestOptions) {
+            return _super.prototype.put.call(_this, url, body, requestOptions);
+        });
+    };
+    /**
+     * Performs a request with `delete` http method.
+     */
+    AdalHttp.prototype.delete = function (url, options) {
+        var _this = this;
+        return this.mergeOptions(url, options)
+            .flatMap(function (requestOptions) {
+            return _super.prototype.delete.call(_this, url, requestOptions);
+        });
+    };
+    /**
+     * Performs a request with `patch` http method.
+     */
+    AdalHttp.prototype.patch = function (url, body, options) {
+        var _this = this;
+        return this.mergeOptions(url, options)
+            .flatMap(function (requestOptions) {
+            return _super.prototype.patch.call(_this, url, body, requestOptions);
+        });
+    };
+    /**
+     * Performs a request with `head` http method.
+     */
+    AdalHttp.prototype.head = function (url, options) {
+        var _this = this;
+        return this.mergeOptions(url, options)
+            .flatMap(function (requestOptions) {
+            return _super.prototype.head.call(_this, url, requestOptions);
+        });
+    };
+    AdalHttp = __decorate([
+        core_1.Injectable(), 
+        __metadata('design:paramtypes', [http_1.ConnectionBackend, http_1.RequestOptions, AdalAuthenticationService])
+    ], AdalHttp);
+    return AdalHttp;
+}(http_1.Http));
+exports.AdalHttp = AdalHttp;
+var AdalAuthenticationService = (function () {
+    function AdalAuthenticationService(config) {
+        this.config = config;
+        this._adal = new AuthenticationContext(config);
+    }
+    AdalAuthenticationService.prototype.logout = function () {
+        this._adal.logout();
+    };
+    AdalAuthenticationService.prototype.getCachedToken = function (resource) {
+        return this._adal.getCachedToken(resource);
+    };
+    AdalAuthenticationService.prototype.acquireToken = function (url) {
+        var _this = this;
+        var resource = this._adal.getResourceForEndpoint(url);
+        return RX_1.Observable.create(function (observer) {
+            _this._adal._renewActive = true;
+            _this._adal.acquireToken(resource, function (error, token) {
+                _this._adal._renewActive = false;
+                if (error) {
+                    observer.error(error);
+                }
+                else {
+                    observer.next(token);
+                }
+            });
+        });
+    };
+    AdalAuthenticationService.prototype.getUser = function () {
+        var _this = this;
+        return RX_1.Observable.create(function (observer) {
+            _this._adal.getUser(function (error, user) {
+                if (error) {
+                    observer.error(error);
+                }
+                else {
+                    observer.next(user);
+                }
+            });
+        });
+    };
+    AdalAuthenticationService = __decorate([
+        core_1.Injectable(), 
+        __metadata('design:paramtypes', [Object])
+    ], AdalAuthenticationService);
+    return AdalAuthenticationService;
+}());
+exports.AdalAuthenticationService = AdalAuthenticationService;
+function provideAdalAuth(config) {
+    return [
+        { provide: AdalAuthenticationService, useFactory: function () { return new AdalAuthenticationService(config); } },
+        { provide: http_1.Http, useFactory: function (connectionBackend, defaultOptions, authService) {
+                return new AdalHttp(connectionBackend, defaultOptions, authService);
+            }, deps: [http_1.XHRBackend, http_1.RequestOptions, AdalAuthenticationService] }
+    ];
+}
+exports.provideAdalAuth = provideAdalAuth;
+var AdalModule = (function () {
+    function AdalModule() {
+    }
+    AdalModule.withConfig = function (config) {
+        return {
+            ngModule: AdalModule,
+            providers: [
+                provideAdalAuth(config)
+            ]
+        };
+    };
+    AdalModule = __decorate([
+        core_1.NgModule({
+            imports: [http_1.HttpModule]
+        }), 
+        __metadata('design:paramtypes', [])
+    ], AdalModule);
+    return AdalModule;
+}());
+exports.AdalModule = AdalModule;

--- a/lib/AdalHttp.ts
+++ b/lib/AdalHttp.ts
@@ -1,0 +1,224 @@
+/// <reference path="../typings/index.d.ts" />
+
+import { Injectable, NgModule, ModuleWithProviders } from '@angular/core';
+import { HttpModule, Http, ConnectionBackend, Request, RequestOptions, RequestOptionsArgs, Response, XHRBackend, Headers } from '@angular/http';
+import { Observable } from 'rxjs/RX';
+
+'use strict';
+
+export interface AdalUser {
+    userName: string;
+    profile: any;
+}
+
+export declare class AuthenticationContext {
+    _renewActive: boolean;
+    constructor(config: AdalConfig);
+    login();
+    getCachedToken(resource: string): string;
+    getCachedUser(): AdalUser;
+    acquireToken(resource: string, callback: (error?: string, token?: string) => void);
+    clearCache();
+    clearCacheForResource(resource: string);
+    logout();
+    getUser(callback: (error?: string, user?: AdalUser) => void);
+    isCallback(hash: string): boolean;
+    getLoginError(): string;
+    getResourceForEndpoint(endpoint: string): string;
+}
+
+export interface AdalConfig {
+    tenant?: string;
+    clientId?: string;
+    redirectUri?: string;
+    instance?: string;
+    endpoints?: any[];
+}
+
+@Injectable()
+export class AdalHttp extends Http {
+    constructor(backend: ConnectionBackend, defaultOptions: RequestOptions, protected adal: AdalAuthenticationService) {
+        super(backend, defaultOptions);
+    }
+
+    protected mergeOptions(url: string | Request, options?: RequestOptionsArgs): Observable<RequestOptionsArgs> {
+        return Observable.create(observer => {
+
+            let resourceUrl = (url instanceof Request) ? url.url : url;
+
+            this.adal.acquireToken(resourceUrl)
+                .subscribe(token => {
+                    // Combine constructor default options with request options
+                    let mergedOptions: RequestOptionsArgs;
+                    if (this._defaultOptions) {
+                        mergedOptions = Object.assign({}, this._defaultOptions);
+                    } else {
+                        mergedOptions = new RequestOptions();
+                    }
+                    if (!mergedOptions.headers) {
+                        mergedOptions.headers = new Headers();
+                    }
+
+                    if (options) {
+                        options.headers.forEach((values, name, headers) => {
+                            mergedOptions.headers.set(name, values);
+                        });
+                        mergedOptions.method = options.method;
+                        mergedOptions.body = options.body;
+                        mergedOptions.search = options.search;
+                    }
+                    
+                    mergedOptions.headers.set('Authorization', `Bearer ${token}`);
+                    observer.next(mergedOptions);
+                }, error => {
+                    observer.error(error);
+                });
+        });
+    }
+
+      /**
+   * Performs any type of http request. First argument is required, and can either be a url or
+   * a {@link Request} instance. If the first argument is a url, an optional {@link RequestOptions}
+   * object can be provided as the 2nd argument. The options object will be merged with the values
+   * of {@link BaseRequestOptions} before performing the request.
+   */
+    request(url: string | Request, options?: RequestOptionsArgs): Observable<Response> {
+        return this.mergeOptions(url, options)
+            .flatMap<Response>(requestOptions => {
+                if (!requestOptions.body) {
+                    requestOptions.body = '';
+                }    
+                return super.request(url, requestOptions);
+            });
+    }
+
+    /**
+     * Performs a request with `get` http method.
+     */
+    get(url: string, options?: RequestOptionsArgs): Observable<Response> {
+        return this.mergeOptions(url, options)
+            .flatMap<Response>(requestOptions => {
+                if (!requestOptions.body) {
+                    requestOptions.body = '';
+                }
+                return super.get(url, requestOptions);
+            });
+    }
+
+    /**
+     * Performs a request with `post` http method.
+     */
+    post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
+        return this.mergeOptions(url, options)
+            .flatMap<Response>(requestOptions => {
+                return super.post(url, body, requestOptions);
+            });        
+    }
+
+    /**
+     * Performs a request with `put` http method.
+     */
+    put(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
+        return this.mergeOptions(url, options)
+            .flatMap<Response>(requestOptions => {
+                return super.put(url, body, requestOptions);
+            });        
+    }
+
+    /**
+     * Performs a request with `delete` http method.
+     */
+    delete(url: string, options?: RequestOptionsArgs): Observable<Response> {
+        return this.mergeOptions(url, options)
+            .flatMap<Response>(requestOptions => {
+                return super.delete(url, requestOptions);
+            });        
+    }
+
+    /**
+     * Performs a request with `patch` http method.
+     */
+    patch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
+        return this.mergeOptions(url, options)
+            .flatMap<Response>(requestOptions => {
+                return super.patch(url, body, requestOptions);
+            });        
+    }
+
+    /**
+     * Performs a request with `head` http method.
+     */
+    head(url: string, options?: RequestOptionsArgs): Observable<Response> {
+        return this.mergeOptions(url, options)
+            .flatMap<Response>(requestOptions => {
+                return super.head(url, requestOptions);
+            });        
+    }
+}
+
+@Injectable()
+export class AdalAuthenticationService {
+    protected _adal: AuthenticationContext;
+    constructor(protected config: AdalConfig) {
+        this._adal = new AuthenticationContext(config);
+    }
+
+    logout() {
+        this._adal.logout();
+    }
+
+    getCachedToken(resource: string): string {
+        return this._adal.getCachedToken(resource);
+    }
+
+    acquireToken(url: string): Observable<string> {
+        const resource = this._adal.getResourceForEndpoint(url);
+
+        return Observable.create(observer => {
+            this._adal._renewActive = true;
+            this._adal.acquireToken(resource, (error, token) => {
+                this._adal._renewActive = false;
+                if (error) {
+                    observer.error(error);
+                } else {
+                    observer.next(token);
+                }
+            });
+        });
+    }
+
+    getUser(): Observable<AdalUser> {
+        return Observable.create(observer => {
+            this._adal.getUser((error, user) => {
+                if (error) {
+                    observer.error(error);
+                } else {
+                    observer.next(user);
+                }
+            });
+        })
+    }
+}
+
+export function provideAdalAuth(config?: AdalConfig): any[] {
+    return [
+        { provide: AdalAuthenticationService, useFactory: () => new AdalAuthenticationService(config) },
+        { provide: Http, useFactory: (connectionBackend: XHRBackend, defaultOptions: RequestOptions, authService: AdalAuthenticationService) => {
+            return new AdalHttp(connectionBackend, defaultOptions, authService);
+        }, deps: [XHRBackend, RequestOptions, AdalAuthenticationService] }
+    ];
+}
+
+@NgModule({
+    imports: [HttpModule]
+})
+export class AdalModule {
+    static withConfig(config?: AdalConfig): ModuleWithProviders {
+        return {
+            ngModule: AdalModule,
+            providers: [
+                provideAdalAuth(config)
+            ]
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -25,11 +25,15 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "jasmine-node": "~1.14.5",
-    "jshint": "*",
+    "@angular/core": "^2.0.0-rc.6",
+    "@angular/http": "^2.0.0-rc.6",
+    "@angular/platform-browser": "^2.0.0-rc.6",
+    "@angular/common": "^2.0.0-rc.6",
+    "@angular/compiler": "^2.0.0-rc.6",
+    "atob": "~1.1.2",
+    "bower": "^1.3.3",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-jsdoc": "~0.5.7",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "^0.3.0",
     "grunt-contrib-connect": "^0.7.1",
@@ -37,18 +41,23 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "~0.6.0",
     "grunt-contrib-watch": "~0.2.0",
+    "grunt-jasmine-node": "~0.2.1",
+    "grunt-jsdoc": "~0.5.7",
     "grunt-karma": "^0.9.x",
-    "atob": "~1.1.2",
-    "karma-chrome-launcher": "~0.1.5",
+    "jasmine-node": "~1.14.5",
+    "jshint": "*",
     "karma": "~0.12.24",
+    "karma-chrome-launcher": "~0.1.5",
     "karma-jasmine": "~0.1.5",
-    "bower": "^1.3.3",
-    "grunt-jasmine-node": "~0.2.1"
+    "rxjs": "^5.0.0-beta.11",
+    "zone.js": "^0.6.17",
+    "typings": "^1.3.2"
   },
   "directories": {
     "test": "tests"
   },
   "scripts": {
+    "postinstall": "./node_modules/.bin/typings install",
     "test": "jasmine-node tests/unit/spec"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "skipDefaultLibCheck": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,8 @@
+{
+  "name": "adal-angular",
+  "dependencies": {},
+  "globalDependencies": {
+    "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504",
+    "node": "registry:dt/node#6.0.0+20160802155038"
+  }
+}


### PR DESCRIPTION
A http subclass for adal to intercept requests and add tokens plus an angular2 service that wraps the adal.js base similar to the existing setup for adal-angular for angular1