### PR TITLE
Add token validation callback

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -153,7 +153,7 @@
                             _adal.acquireToken(_adal.config.loginResource, function (error, tokenOut) {
                                 _adal._renewActive = false;
                                 if (error) {
-                                    $rootScope.$broadcast('adal:loginFailure', 'auto renew failure');
+                                    $rootScope.$broadcast('adal:loginFailure', error);
                                 } else {
                                     if (tokenOut) {
                                         _oauthData.isAuthenticated = true;

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -749,6 +749,7 @@ var AuthenticationContext = (function () {
         this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, '');
 
         var resource = this._getResourceFromState(requestInfo.stateResponse);
+        this._saveItem(this.CONSTANTS.STORAGE.RENEW_STATUS + resource, this.CONSTANTS.TOKEN_RENEW_STATUS_COMPLETED);
 
         // Record error
         if (requestInfo.parameters.hasOwnProperty(this.CONSTANTS.ERROR_DESCRIPTION)) {
@@ -787,6 +788,21 @@ var AuthenticationContext = (function () {
                     this.info('Fragment has id token');
                     this._loginInProgress = false;
 
+                    if (this.config.validateTokenCallback && typeof this.config.validateTokenCallback == 'function') {
+                        var that = this;
+                        var options = { aud: [this.config.clientId] };
+                        var isIdTokenValid = this.config.validateTokenCallback(requestInfo.parameters[this.CONSTANTS.ID_TOKEN], options, function (error) {
+                            if (error) {
+                                that._saveItem(that.CONSTANTS.STORAGE.LOGIN_ERROR, error);
+                                that._saveItem(that.CONSTANTS.STORAGE.ERROR, 'invalid id_token');
+                                that._saveItem(that.CONSTANTS.STORAGE.ERROR_DESCRIPTION, error);
+                                that.error(error);
+                            }
+                        });
+                        if (!isIdTokenValid)
+                            return;
+                    }
+
                     this._user = this._createUser(requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
 
                     if (this._user && this._user.profile) {
@@ -797,8 +813,6 @@ var AuthenticationContext = (function () {
                             this._saveItem(this.CONSTANTS.STORAGE.IDTOKEN, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
 
                             // Save idtoken as access token for app itself
-                            resource = this.config.loginResource ? this.config.loginResource : this.config.clientId;
-
                             if (!this._hasResource(resource)) {
                                 keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
                                 this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + resource + this.CONSTANTS.RESOURCE_DELIMETER);
@@ -817,7 +831,6 @@ var AuthenticationContext = (function () {
                 this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, 'Invalid_state. state: ' + requestInfo.stateResponse);
             }
         }
-        this._saveItem(this.CONSTANTS.STORAGE.RENEW_STATUS + resource, this.CONSTANTS.TOKEN_RENEW_STATUS_COMPLETED);
     };
 
     /**

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -789,6 +789,7 @@ var AuthenticationContext = (function () {
                     this._loginInProgress = false;
 
                     if (this.config.validateTokenCallback && typeof this.config.validateTokenCallback == 'function') {
+                        this.info('Calling validateTokenCallback to validate token')
                         var that = this;
                         var options = { aud: [this.config.clientId] };
                         var isIdTokenValid = this.config.validateTokenCallback(requestInfo.parameters[this.CONSTANTS.ID_TOKEN], options, function (error) {
@@ -799,8 +800,10 @@ var AuthenticationContext = (function () {
                                 that.error(error);
                             }
                         });
-                        if (!isIdTokenValid)
+                        if (!isIdTokenValid) {
+                            this.error('Id token validation failed')
                             return;
+                        }
                     }
 
                     this._user = this._createUser(requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);

--- a/tests/angularModuleSpec.js
+++ b/tests/angularModuleSpec.js
@@ -333,7 +333,7 @@ describe('TaskCtl', function () {
         spyOn(rootScope, '$broadcast').andCallThrough();
         scope.$on('adal:loginFailure', function (event, message) {
             expect(event.name).toBe('adal:loginFailure');
-            expect(message).toBe('auto renew failure');
+            expect(message).toBe('resource is required');
         });
         scope.$apply();
         adalServiceProvider.config.loginResource = loginResourceOldValue;

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -72,6 +72,7 @@ describe('Adal', function () {
     var DEFAULT_INSTANCE = "https://login.microsoftonline.com/";
     var IDTOKEN_MOCK = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjVUa0d0S1JrZ2FpZXpFWTJFc0xDMmdPTGpBNCJ9.eyJhdWQiOiJlOWE1YThiNi04YWY3LTQ3MTktOTgyMS0wZGVlZjI1NWY2OGUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvNTJkNGIwNzItOTQ3MC00OWZiLTg3MjEtYmMzYTFjOTkxMmExLyIsImlhdCI6MTQxMTk1OTAwMCwibmJmIjoxNDExOTU5MDAwLCJleHAiOjE0MTE5NjI5MDAsInZlciI6IjEuMCIsInRpZCI6IjUyZDRiMDcyLTk0NzAtNDlmYi04NzIxLWJjM2ExYzk5MTJhMSIsImFtciI6WyJwd2QiXSwib2lkIjoiZmEzYzVmYTctN2Q5OC00Zjk3LWJmYzQtZGJkM2E0YTAyNDMxIiwidXBuIjoidXNlckBvYXV0aGltcGxpY2l0LmNjc2N0cC5uZXQiLCJ1bmlxdWVfbmFtZSI6InVzZXJAb2F1dGhpbXBsaWNpdC5jY3NjdHAubmV0Iiwic3ViIjoiWTdUbXhFY09IUzI0NGFHa3RjbWpicnNrdk5tU1I4WHo5XzZmbVc2NXloZyIsImZhbWlseV9uYW1lIjoiYSIsImdpdmVuX25hbWUiOiJ1c2VyIiwibm9uY2UiOiI4MGZmYTkwYS1jYjc0LTRkMGYtYTRhYy1hZTFmOTNlMzJmZTAiLCJwd2RfZXhwIjoiNTc3OTkxMCIsInB3ZF91cmwiOiJodHRwczovL3BvcnRhbC5taWNyb3NvZnRvbmxpbmUuY29tL0NoYW5nZVBhc3N3b3JkLmFzcHgifQ.WHsl8TH1rQ3dQbRkV0TS6GBVAxzNOpG3nGG6mpEBCwAOCbyW6qRsSoo4qq8I5IGyerDf2cvcS-zzatHEROpRC9dcpwkRm6ta5dFZuouFyZ_QiYVKSMwfzEC_FI-6p7eT8gY6FbV51bp-Ah_WKJqEmaXv-lqjIpgsMGeWDgZRlB9cPODXosBq-PEk0q27Be-_A-KefQacJuWTX2eEhECLyuAu-ETVJb7s19jQrs_LJXz_ISib4DdTKPa7XTBDJlVGdCI18ctB67XwGmGi8MevkeKqFI8dkykTxeJ0MXMmEQbE6Fw-gxmP7uJYbZ61Jqwsw24zMDMeXatk2VWMBPCuhA';
     var STATE = '33333333-3333-4333-b333-333333333333';
+    var IDTOKEN_MOCK_NONCE = '80ffa90a-cb74-4d0f-a4ac-ae1f93e32fe0';
     var SESSION_STATE = '451c6916-27cf-4eae-81cd-accf96126398';
     var VALID_URLFRAGMENT = 'id_token=' + IDTOKEN_MOCK + '' + '&state=' + STATE + '&session_state=' + SESSION_STATE;
     var INVALID_URLFRAGMENT = 'id_token' + IDTOKEN_MOCK + '' + '&state=' + STATE + '&session_state=' + SESSION_STATE;
@@ -926,6 +927,42 @@ describe('Adal', function () {
         });
 
     });
+
+    it('validates the id token using validateTokenCallback', function () {
+        var requestInfo = {
+            valid: true,
+            parameters: { 'id_token': IDTOKEN_MOCK, 'state': '123' },
+            stateMatch: true,
+            stateResponse: '123|loginResource1',
+            requestType: adal.REQUEST_TYPE.RENEW_TOKEN
+        };
+
+        // when validateTokenCallback returns true
+        adal.config.validateTokenCallback = function (token, options, callback) {
+            callback(null);
+            return true;
+        };
+        storageFake.setItem(adal.CONSTANTS.STORAGE.NONCE_IDTOKEN, IDTOKEN_MOCK_NONCE);
+        adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';
+        adal.saveTokenFromHash(requestInfo);
+        expect(storageFake.getItem(adal.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + 'loginResource1')).toBe(IDTOKEN_MOCK);
+        expect(storageFake.getItem(adal.CONSTANTS.STORAGE.IDTOKEN)).toBe(IDTOKEN_MOCK);
+
+        // when validateTokenCallback returns false
+        adal.config.validateTokenCallback = function (token, options, callback) {
+            callback('signature validation failed');
+            return false;
+        };
+        storageFake.setItem(adal.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + 'loginResource1', '');
+        storageFake.setItem(adal.CONSTANTS.STORAGE.IDTOKEN, '');
+        adal.saveTokenFromHash(requestInfo);
+        expect(storageFake.getItem(adal.CONSTANTS.STORAGE.LOGIN_ERROR)).toBe('signature validation failed');
+        expect(storageFake.getItem(adal.CONSTANTS.STORAGE.ERROR)).toBe('invalid id_token');
+        expect(storageFake.getItem(adal.CONSTANTS.STORAGE.ERROR_DESCRIPTION)).toBe('signature validation failed');
+        expect(storageFake.getItem(adal.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + 'loginResource1')).toBe('');
+        expect(storageFake.getItem(adal.CONSTANTS.STORAGE.IDTOKEN)).toBe('');
+    });
+
     // TODO angular intercepptor
     // TODO angular authenticationService
 });


### PR DESCRIPTION
Partially addresses the #175 by providing an extensibility point for users to plug in for client side token validation.

Also, fixing #360 by passing the error to application when auto renewal of id token fails
