### PR TITLE
add support for templateUrl that is a function. fixes #368

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -198,6 +198,8 @@
                 }
 
                 var routeChangeHandler = function (e, nextRoute) {
+                    var nextRouteUrl;
+
                     if (nextRoute && nextRoute.$$route) {
                         if (isADLoginRequired(nextRoute.$$route, _adal.config)) {
                             if (!_oauthData.isAuthenticated) {
@@ -208,8 +210,14 @@
                             }
                         }
                         else {
-                            if (nextRoute.$$route.templateUrl && !isAnonymousEndpoint(nextRoute.$$route.templateUrl)) {
-                                _adal.config.anonymousEndpoints.push(nextRoute.$$route.templateUrl);
+                            if(typeof nextRoute.$$route.templateUrl === "function") {
+                                nextRouteUrl = nextRoute.$$route.templateUrl(nextRoute.params);
+                            } else {
+                                nextRouteUrl = nextRoute.$$route.templateUrl;
+                            }
+
+                            if (nextRouteUrl && !isAnonymousEndpoint(nextRouteUrl)) {
+                                _adal.config.anonymousEndpoints.push(nextRouteUrl);
                             }
                         }
                     }


### PR DESCRIPTION
The templateUrl property for the routeProvider object can be a string or a function as per angular docs.

if it is a string it returns a path to a html template. if it is a function it is passed the params for the route and returns a string to a template.

adal-angular does not currently handle the case where the templateUrl is a function

NOTE: this patch only fixes the problem for the routeChangeHandler. The stateChangeHandler will also have this problem but only for people using ui-router. I have never used ui-router and don't know how the stateChangeHandler works or is called. i have no way in my project to trigger this event handler to test if toParams is the same type of object or not. Someone will have to write a patch in another PR to handle when the toState.templateUrl is a function. otherwise they will get url.indexOf is not a function errors on state change.