### PR TITLE
Stringify the object when logging

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -276,7 +276,7 @@
                 };
 
                 var stateChangeErrorHandler = function (event, toState, toParams, fromState, fromParams, error) {
-                    _adal.verbose("State change error occured. Error: " + error);
+                    _adal.verbose("State change error occured. Error: " + JSON.stringify(error));
 
                     // adal interceptor sets the error on config.data property. If it is set, it means state change is rejected by adal,
                     // in which case set the defaultPrevented to true to avoid url update as that sometimesleads to infinte loop.
@@ -424,7 +424,7 @@
                     }
                 },
                 responseError: function (rejection) {
-                    authService.info('Getting error in the response.');
+                    authService.info('Getting error in the response: ' + JSON.stringify(rejection));
                     if (rejection) {
                         if (rejection.status === 401) {
                             var resource = authService.getResourceForEndpoint(rejection.config.url);


### PR DESCRIPTION
In adal-angular.js, there is an instance where error is concatenated with a string causing the object to be printed as "[Object object]". This fix stringifies the error object before logging.

I also added a stringified details to the log when an error response is received in adal-angular