### PR TITLE
fix: unreachable return statement

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -419,8 +419,6 @@
                                 return delayedRequest.promise;
                             }
                         }
-
-                        return config;
                     }
                 },
                 responseError: function (rejection) {


### PR DESCRIPTION
The return statement at the end of the function is unreachable due to
the if-else control flow