### PR TITLE
use adfs specific logout url when tenant is adfs

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -546,11 +546,11 @@ var AuthenticationContext = (function () {
         }
 
         var urlNavigate = this.instance + tenant + '/oauth2/logout?' + logout;
-		
-		if (tenant === 'adfs') {
-			urlNavigate = this.instance + '/adfs/ls/?wa=wsignout1.0'
-		}
-		
+
+        if (this.config.logOutUri) {
+            urlNavigate = this.instance + this.config.logOutUri;
+        }
+
         this.info('Logout navigate to: ' + urlNavigate);
         this.promptUser(urlNavigate);
     };

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -534,21 +534,24 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype.logOut = function () {
         this.clearCache();
-        var tenant = 'common';
-        var logout = '';
         this._user = null;
-        if (this.config.tenant) {
-            tenant = this.config.tenant;
-        }
-
-        if (this.config.postLogoutRedirectUri) {
-            logout = 'post_logout_redirect_uri=' + encodeURIComponent(this.config.postLogoutRedirectUri);
-        }
-
-        var urlNavigate = this.instance + tenant + '/oauth2/logout?' + logout;
-
+        var urlNavigate;
+        
         if (this.config.logOutUri) {
-            urlNavigate = this.instance + this.config.logOutUri;
+            urlNavigate = this.config.logOutUri;
+        } else {
+            var tenant = 'common';
+            var logout = '';
+        
+            if (this.config.tenant) {
+                tenant = this.config.tenant;
+            }
+
+            if (this.config.postLogoutRedirectUri) {
+                logout = 'post_logout_redirect_uri=' + encodeURIComponent(this.config.postLogoutRedirectUri);
+            }
+
+            urlNavigate = this.instance + tenant + '/oauth2/logout?' + logout;
         }
 
         this.info('Logout navigate to: ' + urlNavigate);

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -546,6 +546,11 @@ var AuthenticationContext = (function () {
         }
 
         var urlNavigate = this.instance + tenant + '/oauth2/logout?' + logout;
+		
+		if (tenant === 'adfs') {
+			urlNavigate = this.instance + '/adfs/ls/?wa=wsignout1.0'
+		}
+		
         this.info('Logout navigate to: ' + urlNavigate);
         this.promptUser(urlNavigate);
     };

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -410,6 +410,16 @@ describe('Adal', function () {
         expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + 'common/oauth2/logout?post_logout_redirect_uri=https%3A%2F%2Fcontoso.com%2Flogout');
     });
 
+    it('uses adfs specific logout url if tenant is adfs', function (){
+        storageFake.setItem(adal.CONSTANTS.STORAGE.USERNAME, 'test user');
+        adal.config.displayCall = null;
+        adal.config.clientId = 'client';
+        adal.config.tenant = 'adfs'
+        spyOn(adal, 'promptUser');
+        adal.logOut();
+        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + '/adfs/ls/?wa=wsignout1.0');
+    })
+
     it('gets user from cache', function () {
         storageFake.setItem(adal.CONSTANTS.STORAGE.IDTOKEN, IDTOKEN_MOCK);
         adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -414,10 +414,10 @@ describe('Adal', function () {
         storageFake.setItem(adal.CONSTANTS.STORAGE.USERNAME, 'test user');
         adal.config.displayCall = null;
         adal.config.clientId = 'client';
-        adal.config.logOutUri = 'adfs/ls/?wa=wsignout1.0'
+        adal.config.logOutUri = 'https://login.microsoftonline.com/adfs/ls/?wa=wsignout1.0'
         spyOn(adal, 'promptUser');
         adal.logOut();
-        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + 'adfs/ls/?wa=wsignout1.0');
+        expect(adal.promptUser).toHaveBeenCalledWith('https://login.microsoftonline.com/adfs/ls/?wa=wsignout1.0');
     })
 
     it('gets user from cache', function () {

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -410,14 +410,14 @@ describe('Adal', function () {
         expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + 'common/oauth2/logout?post_logout_redirect_uri=https%3A%2F%2Fcontoso.com%2Flogout');
     });
 
-    it('uses adfs specific logout url if tenant is adfs', function (){
+    it('uses logout uri if given', function (){
         storageFake.setItem(adal.CONSTANTS.STORAGE.USERNAME, 'test user');
         adal.config.displayCall = null;
         adal.config.clientId = 'client';
-        adal.config.tenant = 'adfs'
+        adal.config.logOutUri = 'adfs/ls/?wa=wsignout1.0'
         spyOn(adal, 'promptUser');
         adal.logOut();
-        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + '/adfs/ls/?wa=wsignout1.0');
+        expect(adal.promptUser).toHaveBeenCalledWith(DEFAULT_INSTANCE + 'adfs/ls/?wa=wsignout1.0');
     })
 
     it('gets user from cache', function () {


### PR DESCRIPTION
Fixes #389 

Overrides logout navigation url if tenant is adfs.