### PR TITLE
Add Support for Additional OpenID Connect Identity Providers

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "bitwise": true,
+  "bitwise": false,
   "camelcase": true,
   "curly": true,
   "eqeqeq": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,19 +22,14 @@ module.exports = function (grunt) {
         },
         jasmine_node: {
             options: {
-                forceExit: true,
-                match: '.',
-                matchall: false,
-                extensions: 'js',
-                specNameMatcher: 'spec',
-                jUnit: {
+                projectRoot: 'tests/unit/spec',
+                junitreport: {
                     report: true,
-                    savePath: "./build/reports/jasmine/",
+                    savePath: 'build/reports/jasmine',
                     useDotNotation: true,
                     consolidate: true
                 }
-            },
-            all: ['tests/unit/spec/']
+            }
         },
         uglify: {
             options: {

--- a/grunt.txt
+++ b/grunt.txt
@@ -1,0 +1,719 @@
+[4mRunning "jshint:src" (jshint) task[24m
+[32m>> [39m2 files lint free.
+
+[4mRunning "jasmine_node:projectRoot" (jasmine_node) task[24m
+*******************************************************************************
+["tests/unit/spec"]
+*******************************************************************************
+{"specFolders":["tests/unit/spec"],"showColors":true,"teamcity":false,"useRequireJs":false,"regExpSpec":{},"junitreport":{"report":true,"savePath":"build/reports/jasmine","useDotNotation":true,"consolidate":true},"coffee":false,"growl":false}
+[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0mWaiting for initial timeout
+[32m.[0mWaiting for initial timeout
+[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0mWaiting for initial timeout
+[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m
+
+Finished in 2.41 seconds
+[32m100 tests, 190 assertions, 0 failures, 0 skipped
+[0m
+
+
+
+[4mRunning "jasmine_node:junitreport" (jasmine_node) task[24m
+*******************************************************************************
+["tests/unit/spec"]
+*******************************************************************************
+{"specFolders":["tests/unit/spec"],"showColors":true,"teamcity":false,"useRequireJs":false,"regExpSpec":{},"junitreport":{"report":true,"savePath":"build/reports/jasmine","useDotNotation":true,"consolidate":true},"coffee":false,"growl":false}
+[32m.[0m[31mF[0m[31mF[0m[32m.[0m[32m.[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[32m.[0m[31mF[0m[32m.[0m[32m.[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[32m.[0m[32m.[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[32m.[0m[31mF[0m[31mF[0m[32m.[0m[32m.[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[32m.[0m[31mF[0m[32m.[0m[31mF[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m
+
+Failures:
+
+  1) Adal gets default resource for empty endpoint mapping
+   Message:
+     [31mExpected 'loginResource1' to be 'defaultResource'.[0m
+   Stacktrace:
+     Error: Expected 'loginResource1' to be 'defaultResource'.
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:135:50)
+
+  2) Adal gets default resource for empty endpoint mapping
+   Message:
+     [31mExpected 'loginResource1' to be 'defaultResource'.[0m
+   Stacktrace:
+     Error: Expected 'loginResource1' to be 'defaultResource'.
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:136:50)
+
+  3) Adal gets null resource for annonymous endpoints
+   Message:
+     [31mExpected 'loginResource1' to be 'defaultResource'.[0m
+   Stacktrace:
+     Error: Expected 'loginResource1' to be 'defaultResource'.
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:144:57)
+
+  4) Adal navigates user to login by default
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.verbose (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1391:14)
+    at AuthenticationContext.login (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:201:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:169:14)
+
+  5) Adal sets loginprogress to true for login
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.verbose (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1391:14)
+    at AuthenticationContext.login (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:201:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:180:14)
+
+  6) Adal calls displaycall if given for login
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.verbose (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1391:14)
+    at AuthenticationContext.login (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:201:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:195:14)
+
+  7) Adal returns from cache for auto renewable if not expired
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:477:18)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:212:14)
+
+  8) Adal returns error for acquireToken without resource
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.warn (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1383:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:470:18)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:224:14)
+
+  9) Adal attempts to renew if token expired and renew is allowed
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._renewToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:377:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:501:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:240:14)
+
+  10) Adal allows multiple callers to be notified when the token is renewed. Also checks if all registered acquireToken callbacks are called in the case when one of the callbacks throws an error
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._renewToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:377:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:501:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:278:14)
+
+  11) Adal prompts user if url is given
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.promptUser (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:515:18)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:337:14)
+
+  12) Adal clears cache before logout
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.logOut (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:571:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:387:14)
+
+  13) Adal has logout redirect if given
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.logOut (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:571:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:399:14)
+
+  14) Adal uses common for tenant if not given at logout redirect
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.logOut (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:571:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:410:14)
+
+  15) Adal gets user from cache
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.getUser (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:605:18)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:426:14)
+
+  16) Adal gets request info from hash
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.warn (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1383:14)
+    at AuthenticationContext.getRequestInfo (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:769:26)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:449:28)
+
+  17) Adal saves errors token from callback
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:480:14)
+
+  18) Adal saves token if state matches
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:494:14)
+
+  19) Adal saves expiry if state matches
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:507:14)
+
+  20) Adal saves username after extracting idtoken
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:525:14)
+
+  21) Adal does not save user for invalid nonce in idtoken
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:544:14)
+
+  22) Adal saves null for username if idtoken is invalid
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:561:14)
+
+  23) Adal saves null for username if idtoken is invalid
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:578:14)
+
+  24) Adal saves error if state mismatch
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.saveTokenFromHash (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:817:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:634:14)
+
+  25) Adal checks if Logging is defined on window
+   Message:
+     [31mTypeError: Cannot set property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot set property 'level' of undefined
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:640:23)
+
+  26) Adal tests the load frame timeout method
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.verbose (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1391:14)
+    at AuthenticationContext._loadFrameTimeout (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:430:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:650:14)
+
+  27) Adal tests that callbacks are called when renewal token request was canceled
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._renewToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:377:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:501:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:685:14)
+
+  28) Adal attempts to renewidToken if token expired and renew is allowed
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.verbose (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1391:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:498:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:710:14)
+
+  29) Adal tests handleWindowCallback function for RENEW_TOKEN
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.handleWindowCallback (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:957:18)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:748:14)
+
+  30) Adal tests handleWindowCallback function for LOGIN_REQUEST
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext.handleWindowCallback (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:957:18)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:770:14)
+
+  31) Adal use the same correlationId for each request sent to AAD if set by user
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._renewToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:377:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:501:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:786:14)
+
+  32) Adal generates new correlationId for each request sent to AAD if not set by user
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._renewToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:377:14)
+    at AuthenticationContext.acquireToken (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:501:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:810:14)
+
+  33) Adal tests if callback is called after login, if popup window is null
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.verbose (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1391:14)
+    at AuthenticationContext.login (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:201:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:876:14)
+
+  34) Adal tests login functionality in case of popup window
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.verbose (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1391:14)
+    at AuthenticationContext.login (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:201:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:919:14)
+
+  35) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:974:21)
+
+  36) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:987:21)
+
+  37) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1000:21)
+
+  38) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1013:21)
+
+  39) Adal verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1026:21)
+
+  40) Adal verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1039:21)
+
+  41) Adal verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1052:21)
+
+  42) Adal verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1065:21)
+
+  43) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1078:21)
+
+  44) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1091:21)
+
+  45) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1104:21)
+
+  46) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1117:21)
+
+  47) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1130:21)
+
+  48) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1143:21)
+
+  49) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1156:21)
+
+  50) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1169:21)
+
+  51) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1182:21)
+
+  52) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1195:21)
+
+  53) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1208:21)
+
+  54) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1221:21)
+
+  55) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1234:21)
+
+  56) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1247:21)
+
+  57) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1260:21)
+
+  58) Adal verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1273:21)
+
+  59) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1286:21)
+
+  60) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1299:21)
+
+  61) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1312:21)
+
+  62) Adal verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1325:21)
+
+  63) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, and scope and responseType are not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1338:21)
+
+  64) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, scope is not truthy, and responseType is truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1351:21)
+
+  65) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, scope is truthy, and responseType is not truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1364:21)
+
+  66) Adal verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, and scope and responseType are truthy
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.info (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1387:14)
+    at AuthenticationContext._getNavigateUrl (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:986:14)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1377:21)
+
+  67) Adal verifies _createUser() returns null when an aud claim is not contained within the id_token
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.warn (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1383:14)
+    at AuthenticationContext._createUser (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:667:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1382:21)
+
+  68) Adal verifies _createUser() returns null when an unmatching single aud claim is contained within the id_token
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.warn (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1383:14)
+    at AuthenticationContext._createUser (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:667:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1392:21)
+
+  69) Adal verifies _createUser returns null when the id_token contains an matching aud claim within an aud claim array but without a matching azp claim
+   Message:
+     [31mTypeError: Cannot read property 'level' of undefined[0m
+   Stacktrace:
+     TypeError: Cannot read property 'level' of undefined
+    at AuthenticationContext.log (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1359:29)
+    at AuthenticationContext.warn (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:1383:14)
+    at AuthenticationContext._createUser (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\lib\adal.js:667:22)
+    at .<anonymous> (H:\Projects\OpenIdConnectExample\public\azure-activedirectory-library-for-js\tests\unit\spec\AdalSpec.js:1404:21)
+
+Finished in 0.054 seconds
+[31m100 tests, 151 assertions, 69 failures, 0 skipped
+[0m
+
+
+[33mWarning: Task "jasmine_node:junitreport" failed. Use --force to continue.[39m
+
+[31mAborted due to warnings.[39m

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //----------------------------------------------------------------------
+/*global window: false, angular: false, AuthenticationContext: false */
 
 (function () {
     // ============= Angular modules- Start =============
@@ -122,8 +123,9 @@
                                     $rootScope.$broadcast('adal:loginFailure', _adal._getItem(_adal.CONSTANTS.STORAGE.ERROR_DESCRIPTION));
                                 }
 
-                                if (_adal.callback && typeof _adal.callback === 'function')
+                                if (_adal.callback && typeof _adal.callback === 'function') {
                                     _adal.callback(_adal._getItem(_adal.CONSTANTS.STORAGE.ERROR_DESCRIPTION), _adal._getItem(_adal.CONSTANTS.STORAGE.IDTOKEN));
+                                }
 
                                 // redirect to login start page
                                 if (!_adal.popUp) {
@@ -137,8 +139,9 @@
                                         $window.location = loginStartPage;
                                     }
                                 }
-                                else
+                                else {
                                     event.preventDefault();
+                                }
                             }
                         }
                         else {
@@ -234,7 +237,7 @@
                         }
                         else {
                             var nextRouteUrl;
-                            if (typeof nextRoute.$$route.templateUrl === "function") {
+                            if (typeof nextRoute.$$route.templateUrl === 'function') {
                                 nextRouteUrl = nextRoute.$$route.templateUrl(nextRoute.params);
                             } else {
                                 nextRouteUrl = nextRoute.$$route.templateUrl;
@@ -247,7 +250,7 @@
                     }
                 };
 
-                var stateChangeHandler = function (e, toState, toParams, fromState, fromParams) {
+                var stateChangeHandler = function (e, toState, toParams, fromState, fromParams) {  // jshint ignore:line
                     if (toState) {
                         var states = getStates(toState);
                         var state = null;
@@ -278,12 +281,12 @@
                 };
 
                 var stateChangeErrorHandler = function (event, toState, toParams, fromState, fromParams, error) {
-                    _adal.verbose("State change error occured. Error: " + error);
+                    _adal.verbose('State change error occured. Error: ' + error);
 
                     // adal interceptor sets the error on config.data property. If it is set, it means state change is rejected by adal,
                     // in which case set the defaultPrevented to true to avoid url update as that sometimesleads to infinte loop.
                     if (error && error.data) {
-                        _adal.info("Setting defaultPrevented to true if state change error occured because adal rejected a request. Error: " + error.data);
+                        _adal.info('Setting defaultPrevented to true if state change error occured because adal rejected a request. Error: ' + error.data);
                         event.preventDefault();
                     }
                 };
@@ -387,10 +390,11 @@
                         }
                         else {
                             // Cancel request if login is starting
+                            var delayedRequest;
                             if (authService.loginInProgress()) {
                                 if (authService.config.popUp) {
                                     authService.info('Url: ' + config.url + ' will be loaded after login is successful');
-                                    var delayedRequest = $q.defer();
+                                    delayedRequest = $q.defer();
                                     $rootScope.$on('adal:loginSuccess', function (event, token) {
                                         if (token) {
                                             authService.info('Login completed, sending request for ' + config.url);
@@ -408,7 +412,7 @@
                             }
                             else {
                                 // delayed request to return after iframe completes
-                                var delayedRequest = $q.defer();
+                                delayedRequest = $q.defer();
                                 authService.acquireToken(resource).then(function (token) {
                                     authService.verbose('Token is available');
                                     config.headers.Authorization = 'Bearer ' + token;

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -78,11 +78,12 @@
                 var locationChangeHandler = function (event, newUrl, oldUrl) {
                     _adal.verbose('Location change event from ' + oldUrl + ' to ' + newUrl);
                     var hash = $window.location.hash;
+                    var search = $window.location.search;
 
-                    if (_adal.isCallback(hash)) {
+                    if (_adal.isCallback(hash, search)) {
                         // callback can come from login or iframe request
-                        _adal.verbose('Processing the hash: ' + hash);
-                        var requestInfo = _adal.getRequestInfo(hash);
+                        _adal.verbose('Processing Callback, Hash: ' + hash + '; Search String: ' + search);
+                        var requestInfo = _adal.getRequestInfo(hash, search);
                         _adal.saveTokenFromHash(requestInfo);
 
                         // Return to callback if it is sent from iframe

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -178,7 +178,7 @@
                         // directly start login flow
                         _adal.info('Start login at:' + window.location.href);
                         $rootScope.$broadcast('adal:loginRedirect');
-                        _adal.login();
+                        _adal.login($location.absUrl());
                     }
                 };
 

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -22,20 +22,23 @@ var AuthenticationContext = (function () {
     'use strict';
 
     /**
-     * Config information
+     * Config information.  The base instance URL is derived as instance/tenant/rootContext.
+     *                      For example, https://login.microsoftonline.com/common/oauth2.
      * @public
      * @class Config
-     * @property {tenant}          Your target tenant
+     * @property {tenant}          Your target tenant.  This defaults to 'common' if undefined or null.  This is incorporated into the instance URL if non-blank.
      * @property {clientId}        Identifier assigned to your app by Azure Active Directory
      * @property {redirectUri}     Endpoint at which you expect to receive tokens
      * @property {instance}        Azure Active Directory Instance(default:https://login.microsoftonline.com/)
      * @property {endpoints}       Collection of {Endpoint-ResourceId} used for autmatically attaching tokens in webApi calls
+     * @property {rootContext}     This defaults to 'oauth2' if undefined or null.  This is incorporated into the instance URL if non-blank.
+     * @property {scope}           This may be used to define the specific authorization(s) being requested from the resource owner.
      */
 
     /**
      * User information from idtoken.
      *  @class User
-     *  @property {string} userName - username assigned from upn or email.
+     *  @property {string} userName - username assigned from upn, email, or sub (i.e. subject).
      *  @property {object} profile - properties parsed from idtoken.
      */
 
@@ -161,6 +164,13 @@ var AuthenticationContext = (function () {
         if (this.config.isAngular) {
             this.isAngular = this.config.isAngular;
         }
+
+        this._initResponseType();
+    };
+
+    AuthenticationContext.prototype._initResponseType = function() {
+        if (!this.config.responseType)
+            this.config.responseType = this.CONSTANTS.ID_TOKEN;
     };
 
     window.Logging = {
@@ -172,7 +182,7 @@ var AuthenticationContext = (function () {
      * Gets initial Idtoken for the app backend
      * Saves the resulting Idtoken in localStorage.
      */
-    AuthenticationContext.prototype.login = function () {
+    AuthenticationContext.prototype.login = function (startPage) {
         // Token is not present and user needs to login
         if (this._loginInProgress) {
             this.info("Login in progress");
@@ -181,14 +191,16 @@ var AuthenticationContext = (function () {
         var expectedState = this._guid();
         this.config.state = expectedState;
         this._idTokenNonce = this._guid();
-        this.verbose('Expected state: ' + expectedState + ' startPage:' + window.location);
-        this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, window.location);
+        if (!startPage)
+          startPage = window.location;
+        this.verbose('Expected state: ' + expectedState + ' startPage:' + startPage);
+        this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, startPage);
         this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, '');
         this._saveItem(this.CONSTANTS.STORAGE.STATE_LOGIN, expectedState);
         this._saveItem(this.CONSTANTS.STORAGE.NONCE_IDTOKEN, this._idTokenNonce);
         this._saveItem(this.CONSTANTS.STORAGE.ERROR, '');
         this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, '');
-        var urlNavigate = this._getNavigateUrl('id_token', null) + '&nonce=' + encodeURIComponent(this._idTokenNonce);
+        var urlNavigate = this._getNavigateUrl(this.config.responseType, null) + '&nonce=' + encodeURIComponent(this._idTokenNonce);
         this._loginInProgress = true;
         if (this.popUp) {
             this._loginPopup(urlNavigate);
@@ -379,7 +391,7 @@ var AuthenticationContext = (function () {
         this._renewStates.push(expectedState);
 
         this.verbose('Renew Idtoken Expected state: ' + expectedState);
-        var urlNavigate = this._getNavigateUrl('id_token', null) + '&prompt=none';
+        var urlNavigate = this._getNavigateUrl(this.config.responseType, null) + '&prompt=none';
         urlNavigate = this._addHintParameters(urlNavigate);
 
         urlNavigate += '&nonce=' + encodeURIComponent(this._idTokenNonce);
@@ -534,18 +546,14 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype.logOut = function () {
         this.clearCache();
-        var tenant = 'common';
         var logout = '';
         this._user = null;
-        if (this.config.tenant) {
-            tenant = this.config.tenant;
-        }
 
         if (this.config.postLogoutRedirectUri) {
             logout = 'post_logout_redirect_uri=' + encodeURIComponent(this.config.postLogoutRedirectUri);
         }
 
-        var urlNavigate = this.instance + tenant + '/oauth2/logout?' + logout;
+        var urlNavigate = this._getBaseUrl() + 'logout?' + logout;
         this.info('Logout navigate to: ' + urlNavigate);
         this.promptUser(urlNavigate);
     };
@@ -611,7 +619,23 @@ var AuthenticationContext = (function () {
         var user = null;
         var parsedJson = this._extractIdToken(idToken);
         if (parsedJson && parsedJson.hasOwnProperty('aud')) {
-            if (parsedJson.aud.toLowerCase() === this.config.clientId.toLowerCase()) {
+            var audienceMatch = false;
+
+            if (Array.isArray(parsedJson.aud)) {
+                // If the ID Token contains multiple audiences then an azp claim must be present and equal to the client id.
+                if (parsedJson.hasOwnProperty('azp') && parsedJson.azp.toLowerCase() === this.config.clientId.toLowerCase()) {
+                    for (var i = 0; i < parsedJson.aud.length; i++) {
+                        if (parsedJson.aud[i].toLowerCase() === this.config.clientId.toLowerCase()) {
+                            audienceMatch = true;
+                            break;
+                        }
+                    }
+                }
+            } else {
+                audienceMatch = (parsedJson.aud.toLowerCase() === this.config.clientId.toLowerCase());
+            }
+
+            if (audienceMatch) {
 
                 user = {
                     userName: '',
@@ -622,9 +646,11 @@ var AuthenticationContext = (function () {
                     user.userName = parsedJson.upn;
                 } else if (parsedJson.hasOwnProperty('email')) {
                     user.userName = parsedJson.email;
+                } else if (parsedJson.hasOwnProperty('sub')) {
+                  user.userName = parsedJson.sub;
                 }
             } else {
-                this.warn('IdToken has invalid aud field');
+                this.warn('IdToken has invalid aud/azp field');
             }
 
         }
@@ -896,14 +922,34 @@ var AuthenticationContext = (function () {
     };
 
     AuthenticationContext.prototype._getNavigateUrl = function (responseType, resource) {
-        var tenant = 'common';
-        if (this.config.tenant) {
-            tenant = this.config.tenant;
-        }
-
-        var urlNavigate = this.instance + tenant + '/oauth2/authorize' + this._serialize(responseType, this.config, resource) + this._addLibMetadata();
+        var urlNavigate = this._getBaseUrl() + 'authorize' + this._serialize(responseType, this.config, resource) + this._addLibMetadata();
+        if (this.config.scope)
+          urlNavigate += '&scope=' + encodeURIComponent(this.config.scope);
         this.info('Navigate url:' + urlNavigate);
         return urlNavigate;
+    };
+
+    AuthenticationContext.prototype._getBaseUrl = function() {
+      var tenant = 'common';
+      var rootContext = 'oauth2';
+
+      var baseUrl = this.instance;
+
+      if ([undefined, null].indexOf(this.config.tenant) === -1) {
+        tenant = this.config.tenant;
+      }
+
+      if ([undefined, null].indexOf(this.config.rootContext) === -1) {
+        rootContext = this.config.rootContext;
+      }
+
+      if (tenant)
+        baseUrl += tenant + '/';
+
+      if (rootContext)
+        baseUrl += rootContext + '/';
+
+        return baseUrl;
     };
 
     AuthenticationContext.prototype._extractIdToken = function (encodedIdToken) {
@@ -941,7 +987,7 @@ var AuthenticationContext = (function () {
         }
     };
 
-    //Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference. 
+    //Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference.
     AuthenticationContext.prototype._decode = function (base64IdToken) {
         var codes = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
         base64IdToken = String(base64IdToken).replace(/=+$/, '');
@@ -1019,7 +1065,7 @@ var AuthenticationContext = (function () {
     AuthenticationContext.prototype._serialize = function (responseType, obj, resource) {
         var str = [];
         if (obj !== null) {
-            str.push('?response_type=' + responseType);
+            str.push('?response_type=' + encodeURIComponent(responseType));
             str.push('client_id=' + encodeURIComponent(obj.clientId));
             if (resource) {
                 str.push('resource=' + encodeURIComponent(resource));
@@ -1297,4 +1343,3 @@ var AuthenticationContext = (function () {
     return AuthenticationContext;
 
 }());
-

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -270,7 +270,7 @@ var AuthenticationContext = (function () {
                         window.location.hash = popupWindow.location.hash;
                     }
                     else {
-                        that.handleWindowCallback(popupWindow.location.hash);
+                        that.handleWindowCallback(popupWindow.location.hash, popupWindow.location.search);
                     }
                     window.clearInterval(pollTimer);
                     that._loginInProgress = false;
@@ -668,14 +668,45 @@ var AuthenticationContext = (function () {
         return hash;
     };
 
+    AuthenticationContext.prototype._getSearch = function (search) {
+        if (search.indexOf('?') > -1)
+            search = search.substring(1);
+
+        return search;
+    };    
+
+    AuthenticationContext.prototype._getParameters = function(hash, search) {
+        var parameters = {};
+
+        if (hash) {
+            hash = this._getHash(hash);
+            parameters = this._deserialize(hash);
+        }
+
+        if (search) {
+            search = this._getSearch(search);
+            var searchParameters = this._deserialize(search);
+            parameters = this._extend(parameters, searchParameters); 
+        }
+
+        return parameters;
+    };
+
+    AuthenticationContext.prototype._extend = function(obj, src) {
+        for (var key in src) {
+            if (src.hasOwnProperty(key)) obj[key] = src[key];
+        }
+        return obj;
+    }
+
     /**
      * Checks if hash contains access token or id token or error_description
      * @param {string} hash  -  Hash passed from redirect page
      * @returns {Boolean}
      */
-    AuthenticationContext.prototype.isCallback = function (hash) {
-        hash = this._getHash(hash);
-        var parameters = this._deserialize(hash);
+    AuthenticationContext.prototype.isCallback = function (hash, search) {
+        var parameters = this._getParameters(hash, search);
+
         return (
             parameters.hasOwnProperty(this.CONSTANTS.ERROR_DESCRIPTION) ||
             parameters.hasOwnProperty(this.CONSTANTS.ACCESS_TOKEN) ||
@@ -695,9 +726,8 @@ var AuthenticationContext = (function () {
      * Gets requestInfo from given hash.
      * @returns {string} error message related to login
      */
-    AuthenticationContext.prototype.getRequestInfo = function (hash) {
-        hash = this._getHash(hash);
-        var parameters = this._deserialize(hash);
+    AuthenticationContext.prototype.getRequestInfo = function (hash, search) {
+        var parameters = this._getParameters(hash, search);
         var requestInfo = {
             valid: false,
             parameters: {},
@@ -894,13 +924,16 @@ var AuthenticationContext = (function () {
     };
 
     /*exported  oauth2Callback */
-    AuthenticationContext.prototype.handleWindowCallback = function (hash) {
+    AuthenticationContext.prototype.handleWindowCallback = function (hash, search) {
         // This is for regular javascript usage for redirect handling
         // need to make sure this is for callback
         if (hash == null)
             hash = window.location.hash;
-        if (this.isCallback(hash)) {
-            var requestInfo = this.getRequestInfo(hash);
+        if (search == null)
+            search = window.location.search;
+
+        if (this.isCallback(hash, search)) {
+            var requestInfo = this.getRequestInfo(hash, search);
             this.info('Returned from redirect url');
             this.saveTokenFromHash(requestInfo);
             var callback = null;

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //----------------------------------------------------------------------
+/*global window: false, document: false, localStorage: false, sessionStorage: false, Logging: false */
 
 var AuthenticationContext = (function () {
 
@@ -138,11 +139,13 @@ var AuthenticationContext = (function () {
 
         this.config = this._cloneConfig(config);
 
-        if (this.config.popUp)
+        if (this.config.popUp) {
             this.popUp = true;
+        }
 
-        if (this.config.callback && typeof this.config.callback === 'function')
+        if (this.config.callback && typeof this.config.callback === 'function') {
             this.callback = this.config.callback;
+        }
 
         if (this.config.instance) {
             this.instance = this.config.instance;
@@ -169,13 +172,14 @@ var AuthenticationContext = (function () {
     };
 
     AuthenticationContext.prototype._initResponseType = function() {
-        if (!this.config.responseType)
+        if (!this.config.responseType) {
             this.config.responseType = this.CONSTANTS.ID_TOKEN;
+        }
     };
 
     window.Logging = {
         level: 0,
-        log: function (message) { }
+        log: function (message) { }  // jshint ignore:line
     };
 
     /**
@@ -185,14 +189,15 @@ var AuthenticationContext = (function () {
     AuthenticationContext.prototype.login = function (startPage) {
         // Token is not present and user needs to login
         if (this._loginInProgress) {
-            this.info("Login in progress");
+            this.info('Login in progress');
             return;
         }
         var expectedState = this._guid();
         this.config.state = expectedState;
         this._idTokenNonce = this._guid();
-        if (!startPage)
+        if (!startPage) {
           startPage = window.location;
+        }
         this.verbose('Expected state: ' + expectedState + ' startPage:' + startPage);
         this._saveItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST, startPage);
         this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, '');
@@ -241,23 +246,27 @@ var AuthenticationContext = (function () {
             this._loginInProgress = false;
             return null;
         }
-    }
+    };
 
     AuthenticationContext.prototype._loginPopup = function (urlNavigate) {
-        var popupWindow = this._openPopup(urlNavigate, "login", this.CONSTANTS.POPUP_WIDTH, this.CONSTANTS.POPUP_HEIGHT);
-        if (popupWindow == null) {
+        var popupWindow = this._openPopup(urlNavigate, 'login', this.CONSTANTS.POPUP_WIDTH, this.CONSTANTS.POPUP_HEIGHT);
+        if (popupWindow === null) {
             this.warn('Popup Window is null. This can happen if you are using IE');
             this._saveItem(this.CONSTANTS.STORAGE.ERROR, 'Error opening popup');
             this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, 'Popup Window is null. This can happen if you are using IE');
             this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, 'Popup Window is null. This can happen if you are using IE');
-            if (this.callback)
+            if (this.callback) {
                 this.callback(this._getItem(this.CONSTANTS.STORAGE.LOGIN_ERROR), null);
+            }
             return;
         }
-        if (this.config.redirectUri.indexOf('#') != -1)
-            var registeredRedirectUri = this.config.redirectUri.split("#")[0];
-        else
-            var registeredRedirectUri = this.config.redirectUri;
+        var registeredRedirectUri;
+        if (this.config.redirectUri.indexOf('#') !== -1) {
+            registeredRedirectUri = this.config.redirectUri.split('#')[0];
+        }
+        else {
+            registeredRedirectUri = this.config.redirectUri;
+        }
         var that = this;
         var pollTimer = window.setInterval(function () {
             if (!popupWindow || popupWindow.closed || popupWindow.closed === undefined) {
@@ -265,7 +274,7 @@ var AuthenticationContext = (function () {
                 window.clearInterval(pollTimer);
             }
             try {
-                if (popupWindow.location.href.indexOf(registeredRedirectUri) != -1) {
+                if (popupWindow.location.href.indexOf(registeredRedirectUri) !== -1) {
                     if (that.isAngular) {
                         window.location.hash = popupWindow.location.hash;
                     }
@@ -274,7 +283,7 @@ var AuthenticationContext = (function () {
                     }
                     window.clearInterval(pollTimer);
                     that._loginInProgress = false;
-                    that.info("Closing popup window");
+                    that.info('Closing popup window');
                     popupWindow.close();
                 }
             } catch (e) {
@@ -410,9 +419,9 @@ var AuthenticationContext = (function () {
 
     AuthenticationContext.prototype._urlContainsQueryStringParameter = function (name, url) {
         // regex to detect pattern of a ? or & followed by the name parameter and an equals character
-        var regex = new RegExp("[\\?&]" + name + "=");
+        var regex = new RegExp('[\\?&]' + name + '=');
         return regex.test(url);
-    }
+    };
 
     // Calling _loadFrame but with a timeout to signal failure in loadframeStatus. Callbacks are left
     // registered when network errors occur and subsequent token requests for same resource are registered to the pending request
@@ -434,7 +443,7 @@ var AuthenticationContext = (function () {
                 self._saveItem(self.CONSTANTS.STORAGE.RENEW_STATUS + resource, self.CONSTANTS.TOKEN_RENEW_STATUS_CANCELED);
             }
         }, self.CONSTANTS.LOADFRAME_TIMEOUT);
-    }
+    };
 
     AuthenticationContext.prototype._loadFrame = function (urlNavigate, frameName) {
         // This trick overcomes iframe navigation in IE
@@ -610,7 +619,7 @@ var AuthenticationContext = (function () {
             urlNavigate += '&login_hint=' + encodeURIComponent(this._user.profile.upn);
 
             // don't add domain_hint twice if user provided it in the extraQueryParameter value
-            if (!this._urlContainsQueryStringParameter("domain_hint", urlNavigate) && this._user.profile.upn.indexOf('@') > -1) {
+            if (!this._urlContainsQueryStringParameter('domain_hint', urlNavigate) && this._user.profile.upn.indexOf('@') > -1) {
                 var parts = this._user.profile.upn.split('@');
                 // local part can include @ in quotes. Sending last part handles that.
                 urlNavigate += '&domain_hint=' + encodeURIComponent(parts[parts.length - 1]);
@@ -618,7 +627,7 @@ var AuthenticationContext = (function () {
         }
 
         return urlNavigate;
-    }
+    };
 
     AuthenticationContext.prototype._createUser = function (idToken) {
         var user = null;
@@ -674,8 +683,9 @@ var AuthenticationContext = (function () {
     };
 
     AuthenticationContext.prototype._getSearch = function (search) {
-        if (search.indexOf('?') > -1)
+        if (search.indexOf('?') > -1) {
             search = search.substring(1);
+        }
 
         return search;
     };    
@@ -699,10 +709,12 @@ var AuthenticationContext = (function () {
 
     AuthenticationContext.prototype._extend = function(obj, src) {
         for (var key in src) {
-            if (src.hasOwnProperty(key)) obj[key] = src[key];
+            if (src.hasOwnProperty(key)) {
+                obj[key] = src[key];
+            }
         }
         return obj;
-    }
+    };
 
     /**
      * Checks if hash contains access token or id token or error_description
@@ -816,7 +828,7 @@ var AuthenticationContext = (function () {
 
             if (requestInfo.requestType === this.REQUEST_TYPE.LOGIN) {
                 this._loginInProgress = false;
-                this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, requestInfo.parameters.error_description);
+                this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, requestInfo.parameters.error_description);  // jshint ignore:line
             }
         } else {
             // It must verify the state from redirect
@@ -932,10 +944,13 @@ var AuthenticationContext = (function () {
     AuthenticationContext.prototype.handleWindowCallback = function (hash, search) {
         // This is for regular javascript usage for redirect handling
         // need to make sure this is for callback
-        if (hash == null)
+       if (!hash) {
             hash = window.location.hash;
-        if (search == null)
+        }
+
+        if (!search) {
             search = window.location.search;
+        }
 
         if (this.isCallback(hash, search)) {
             var requestInfo = this.getRequestInfo(hash, search);
@@ -946,23 +961,28 @@ var AuthenticationContext = (function () {
                 // iframe call but same single page
                 this.verbose('Window is in iframe');
                 callback = window.parent.callBackMappedToRenewStates[requestInfo.stateResponse];
-                if (callback)
+                if (callback) {
                     callback(this._getItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN] || requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
+                }
                 return;
             } else if (requestInfo.requestType === this.REQUEST_TYPE.LOGIN) {
                 callback = this.callback;
-                if (callback)
+                if (callback) {
                     callback(this._getItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION), requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
+                }
             }
-            if (!this.popUp)// No need to redirect user in case of popup
+            // No need to redirect user in case of popup
+            if (!this.popUp) {
                 window.location = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
+            }
         }
     };
 
     AuthenticationContext.prototype._getNavigateUrl = function (responseType, resource) {
         var urlNavigate = this._getBaseUrl() + 'authorize' + this._serialize(responseType, this.config, resource) + this._addLibMetadata();
-        if (this.config.scope)
+        if (this.config.scope) {
           urlNavigate += '&scope=' + encodeURIComponent(this.config.scope);
+        }
         this.info('Navigate url:' + urlNavigate);
         return urlNavigate;
     };
@@ -981,11 +1001,13 @@ var AuthenticationContext = (function () {
         rootContext = this.config.rootContext;
       }
 
-      if (tenant)
+      if (tenant) {
         baseUrl += tenant + '/';
+      }
 
-      if (rootContext)
+      if (rootContext) {
         baseUrl += rootContext + '/';
+      }
 
         return baseUrl;
     };
@@ -1021,7 +1043,7 @@ var AuthenticationContext = (function () {
             return decodeURIComponent(escape(window.atob(base64IdToken))); // jshint ignore:line
         }
         else {
-            return decodeURIComponent(escape(this._decode(base64IdToken)));
+            return decodeURIComponent(escape(this._decode(base64IdToken))); // jshint ignore:line
         }
     };
 
@@ -1054,7 +1076,7 @@ var AuthenticationContext = (function () {
             }
                 // if last one is '='
             else if (i + 1 === length - 1) {
-                bits = h1 << 18 | h2 << 12
+                bits = h1 << 18 | h2 << 12;
                 c1 = bits >> 16 & 255;
                 decoded += String.fromCharCode(c1);
                 break;
@@ -1077,7 +1099,7 @@ var AuthenticationContext = (function () {
     AuthenticationContext.prototype._decodeJwt = function (jwtToken) {
         if (this._isEmpty(jwtToken)) {
             return null;
-        };
+        }
 
         var idTokenPartsRegex = /^([^\.\s]*)\.([^\.\s]+)\.([^\.\s]*)$/;
 
@@ -1150,7 +1172,7 @@ var AuthenticationContext = (function () {
             hex = '0' + hex;
         }
         return hex;
-    }
+    };
 
     /* jshint ignore:start */
     AuthenticationContext.prototype._guid = function () {
@@ -1338,10 +1360,12 @@ var AuthenticationContext = (function () {
             var timestamp = new Date().toUTCString();
             var formattedMessage = '';
 
-            if (this.config.correlationId)
+            if (this.config.correlationId) {
                 formattedMessage = timestamp + ':' + this.config.correlationId + '-' + this._libVersion() + '-' + this.CONSTANTS.LEVEL_STRING_MAP[level] + ' ' + message;
-            else
+            }
+            else {
                 formattedMessage = timestamp + ':' + this._libVersion() + '-' + this.CONSTANTS.LEVEL_STRING_MAP[level] + ' ' + message;
+            }
 
             if (error) {
                 formattedMessage += '\nstack:\n' + error.stack;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-concat": "^0.3.0",
     "grunt-contrib-connect": "^0.7.1",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "~0.6.0",
     "grunt-contrib-watch": "~0.2.0",
     "grunt-karma": "^0.9.x",
@@ -43,7 +43,7 @@
     "karma": "~0.12.24",
     "karma-jasmine": "~0.1.5",
     "bower": "^1.3.3",
-    "grunt-jasmine-node": "~0.2.1"
+    "grunt-jasmine-node": "~0.3.1"
   },
   "directories": {
     "test": "tests"

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -956,6 +956,462 @@ describe('Adal', function () {
         expect(adal._guid()).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f');
         window.crypto = null;
     });
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, and scope and responseType are not truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = undefined;
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/oauth2\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = undefined;
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/oauth2\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = undefined;
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/oauth2\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are undefined, and scope and responseType are truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = undefined;
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/oauth2\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, and scope and responseType are not truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = '';
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = '';
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });    
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = '';
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });     
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is undefined, rootContext is blank, and scope and responseType are truthy', function() {
+        adal.config.tenant = undefined;
+        adal.config.rootContext = '';
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/common\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });        
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, and scope and responseType are not truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = undefined;
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/oauth2\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = undefined;
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/oauth2\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = undefined;
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/oauth2\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is undefined, and scope and responseType are truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = undefined;
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/oauth2\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, and scope and responseType are not truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = '';
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });     
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = '';
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });  
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = '';
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });        
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are blank, and scope and responseType are truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = '';
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });  
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, and scope and responseType are not truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = undefined;
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/oauth2\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });      
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = undefined;
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/oauth2\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });    
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = undefined;
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/oauth2\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is undefined, and scope and responseType are truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = undefined;
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/oauth2\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, and scope and responseType are not truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = '';
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = '';
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });    
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = '';
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });       
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is non-blank, rootContext is blank, and scope and responseType are truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = '';
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });       
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, and scope and responseType are not truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/another_context\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });     
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/another_context\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/another_context\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant and rootContext are non-blank, and scope and responseType are truthy', function() {
+        adal.config.tenant = 'contoso';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/contoso\/another_context\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    }); 
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, and scope and responseType are not truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = '';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/another_context\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });     
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, scope is not truthy, and responseType is truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = '';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/another_context\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*/);
+    });    
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, scope is truthy, and responseType is not truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = 'openid';
+        adal.config.responseType = '';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/another_context\/authorize\?response_type=id_token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });  
+
+    it('verifies _getNavigateUrl() returns the correct value when tenant is blank, rootContext is non-blank, and scope and responseType are truthy', function() {
+        adal.config.tenant = '';
+        adal.config.rootContext = 'another_context';
+        adal.config.scope = 'openid';
+        adal.config.responseType = 'id_token token';
+        adal._initResponseType();
+        adal.config.clientId = 'the_client_id';
+        adal.config.redirectUri = 'the_redirect_uri';
+        adal.config.state = 'the_state';
+        adal.config.correlationId = 'the_correlation_id';
+        expect(adal._getNavigateUrl(adal.config.responseType, '')).toMatch(/https:\/\/login\.microsoftonline\.com\/another_context\/authorize\?response_type=id_token%20token&client_id=the_client_id&redirect_uri=the_redirect_uri&state=the_state&client-request-id=the_correlation_id.*&scope=openid/);
+    });  
+
+    it('verifies _createUser() returns null when an aud claim is not contained within the id_token', function() {
+        var TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjVUa0d0S1JrZ2FpZXpFWTJFc0xDMmdPTGpBNCJ9.eyJhdWQiOiJlOWE1YThiNi04YWY3LTQ3MTktOTgyMS0wZGVlZjI1NWY2OGUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvNTJkNGIwNzItOTQ3MC00OWZiLTg3MjEtYmMzYTFjOTkxMmExLyIsImlhdCI6MTQxMTk1OTAwMCwibmJmIjoxNDExOTU5MDAwLCJleHAiOjE0MTE5NjI5MDAsInZlciI6IjEuMCIsInRpZCI6IjUyZDRiMDcyLTk0NzAtNDlmYi04NzIxLWJjM2ExYzk5MTJhMSIsImFtciI6WyJwd2QiXSwib2lkIjoiZmEzYzVmYTctN2Q5OC00Zjk3LWJmYzQtZGJkM2E0YTAyNDMxIiwidXBuIjoidXNlckBvYXV0aGltcGxpY2l0LmNjc2N0cC5uZXQiLCJ1bmlxdWVfbmFtZSI6InVzZXJAb2F1dGhpbXBsaWNpdC5jY3NjdHAubmV0Iiwic3ViIjoiWTdUbXhFY09IUzI0NGFHa3RjbWpicnNrdk5tU1I4WHo5XzZmbVc2NXloZyIsImZhbWlseV9uYW1lIjoiYSIsImdpdmVuX25hbWUiOiJ1c2VyIiwibm9uY2UiOiI4MGZmYTkwYS1jYjc0LTRkMGYtYTRhYy1hZTFmOTNlMzJmZTAiLCJwd2RfZXhwIjoiNTc3OTkxMCIsInB3ZF91cmwiOiJodHRwczovL3BvcnRhbC5taWNyb3NvZnRvbmxpbmUuY29tL0NoYW5nZVBhc3N3b3JkLmFzcHgifQ.eyJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvNTJkNGIwNzItOTQ3MC00OWZiLTg3MjEtYmMzYTFjOTkxMmExLyIsImlhdCI6MTQxMTk1OTAwMCwibmJmIjoxNDExOTU5MDAwLCJleHAiOjE0MTE5NjI5MDAsInZlciI6IjEuMCIsInRpZCI6IjUyZDRiMDcyLTk0NzAtNDlmYi04NzIxLWJjM2ExYzk5MTJhMSIsImFtciI6WyJwd2QiXSwib2lkIjoiZmEzYzVmYTctN2Q5OC00Zjk3LWJmYzQtZGJkM2E0YTAyNDMxIiwidXBuIjoidXNlckBvYXV0aGltcGxpY2l0LmNjc2N0cC5uZXQiLCJ1bmlxdWVfbmFtZSI6InVzZXJAb2F1dGhpbXBsaWNpdC5jY3NjdHAubmV0Iiwic3ViIjoiWTdUbXhFY09IUzI0NGFHa3RjbWpicnNrdk5tU1I4WHo5XzZmbVc2NXloZyIsImZhbWlseV9uYW1lIjoiYSIsImdpdmVuX25hbWUiOiJ1c2VyIiwibm9uY2UiOiI4MGZmYTkwYS1jYjc0LTRkMGYtYTRhYy1hZTFmOTNlMzJmZTAiLCJwd2RfZXhwIjoiNTc3OTkxMCIsInB3ZF91cmwiOiJodHRwczovL3BvcnRhbC5taWNyb3NvZnRvbmxpbmUuY29tL0NoYW5nZVBhc3N3b3JkLmFzcHgifQ==";
+        expect(adal._createUser(TOKEN)).toBe(null);
+    });
+
+    it('verifies _createUser() returns user object with userName matching the upn contained within the id_token when a single aud claim matching the clientId is present', function() {
+        adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';
+        expect(adal._createUser(IDTOKEN_MOCK).userName).toBe('user@oauthimplicit.ccsctp.net');
+    });
+
+    it('verifies _createUser() returns null when an unmatching single aud claim is contained within the id_token', function() {
+        adal.config.clientId = 'not-a-match';
+        expect(adal._createUser(IDTOKEN_MOCK)).toBe(null);
+    });
+
+    it('verifies _createUser returns user object with userName matching the upn contained within the id_token when an aud claim array is present and a matching azp claim is present', function() {
+        adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';
+        var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjVUa0d0S1JrZ2FpZXpFWTJFc0xDMmdPTGpBNCJ9.eyJhdWQiOlsiZTlhNWE4YjYtOGFmNy00NzE5LTk4MjEtMGRlZWYyNTVmNjhlIl0sImF6cCI6ImU5YTVhOGI2LThhZjctNDcxOS05ODIxLTBkZWVmMjU1ZjY4ZSIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MtcHBlLm5ldC81MmQ0YjA3Mi05NDcwLTQ5ZmItODcyMS1iYzNhMWM5OTEyYTEvIiwiaWF0IjoxNDExOTU5MDAwLCJuYmYiOjE0MTE5NTkwMDAsImV4cCI6MTQxMTk2MjkwMCwidmVyIjoiMS4wIiwidGlkIjoiNTJkNGIwNzItOTQ3MC00OWZiLTg3MjEtYmMzYTFjOTkxMmExIiwiYW1yIjpbInB3ZCJdLCJvaWQiOiJmYTNjNWZhNy03ZDk4LTRmOTctYmZjNC1kYmQzYTRhMDI0MzEiLCJ1cG4iOiJ1c2VyQG9hdXRoaW1wbGljaXQuY2NzY3RwLm5ldCIsInVuaXF1ZV9uYW1lIjoidXNlckBvYXV0aGltcGxpY2l0LmNjc2N0cC5uZXQiLCJzdWIiOiJZN1RteEVjT0hTMjQ0YUdrdGNtamJyc2t2Tm1TUjhYejlfNmZtVzY1eWhnIiwiZmFtaWx5X25hbWUiOiJhIiwiZ2l2ZW5fbmFtZSI6InVzZXIiLCJub25jZSI6IjgwZmZhOTBhLWNiNzQtNGQwZi1hNGFjLWFlMWY5M2UzMmZlMCIsInB3ZF9leHAiOiI1Nzc5OTEwIiwicHdkX3VybCI6Imh0dHBzOi8vcG9ydGFsLm1pY3Jvc29mdG9ubGluZS5jb20vQ2hhbmdlUGFzc3dvcmQuYXNweCJ9.WHsl8TH1rQ3dQbRkV0TS6GBVAxzNOpG3nGG6mpEBCwAOCbyW6qRsSoo4qq8I5IGyerDf2cvcS-zzatHEROpRC9dcpwkRm6ta5dFZuouFyZ_QiYVKSMwfzEC_FI-6p7eT8gY6FbV51bp-Ah_WKJqEmaXv-lqjIpgsMGeWDgZRlB9cPODXosBq-PEk0q27Be-_A-KefQacJuWTX2eEhECLyuAu-ETVJb7s19jQrs_LJXz_ISib4DdTKPa7XTBDJlVGdCI18ctB67XwGmGi8MevkeKqFI8dkykTxeJ0MXMmEQbE6Fw-gxmP7uJYbZ61Jqwsw24zMDMeXatk2VWMBPCuhA';
+        expect(adal._createUser(TOKEN).userName).toBe('user@oauthimplicit.ccsctp.net');
+    });
+
+    it('verifies _createUser returns null when the id_token contains an matching aud claim within an aud claim array but without a matching azp claim', function() {
+        adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';
+        var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjVUa0d0S1JrZ2FpZXpFWTJFc0xDMmdPTGpBNCJ9.eyJhdWQiOlsiZTlhNWE4YjYtOGFmNy00NzE5LTk4MjEtMGRlZWYyNTVmNjhlIl0sImF6cCI6Im5vdC1hLW1hdGNoIiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy1wcGUubmV0LzUyZDRiMDcyLTk0NzAtNDlmYi04NzIxLWJjM2ExYzk5MTJhMS8iLCJpYXQiOjE0MTE5NTkwMDAsIm5iZiI6MTQxMTk1OTAwMCwiZXhwIjoxNDExOTYyOTAwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiI1MmQ0YjA3Mi05NDcwLTQ5ZmItODcyMS1iYzNhMWM5OTEyYTEiLCJhbXIiOlsicHdkIl0sIm9pZCI6ImZhM2M1ZmE3LTdkOTgtNGY5Ny1iZmM0LWRiZDNhNGEwMjQzMSIsInVwbiI6InVzZXJAb2F1dGhpbXBsaWNpdC5jY3NjdHAubmV0IiwidW5pcXVlX25hbWUiOiJ1c2VyQG9hdXRoaW1wbGljaXQuY2NzY3RwLm5ldCIsInN1YiI6Ilk3VG14RWNPSFMyNDRhR2t0Y21qYnJza3ZObVNSOFh6OV82Zm1XNjV5aGciLCJmYW1pbHlfbmFtZSI6ImEiLCJnaXZlbl9uYW1lIjoidXNlciIsIm5vbmNlIjoiODBmZmE5MGEtY2I3NC00ZDBmLWE0YWMtYWUxZjkzZTMyZmUwIiwicHdkX2V4cCI6IjU3Nzk5MTAiLCJwd2RfdXJsIjoiaHR0cHM6Ly9wb3J0YWwubWljcm9zb2Z0b25saW5lLmNvbS9DaGFuZ2VQYXNzd29yZC5hc3B4In0=.WHsl8TH1rQ3dQbRkV0TS6GBVAxzNOpG3nGG6mpEBCwAOCbyW6qRsSoo4qq8I5IGyerDf2cvcS-zzatHEROpRC9dcpwkRm6ta5dFZuouFyZ_QiYVKSMwfzEC_FI-6p7eT8gY6FbV51bp-Ah_WKJqEmaXv-lqjIpgsMGeWDgZRlB9cPODXosBq-PEk0q27Be-_A-KefQacJuWTX2eEhECLyuAu-ETVJb7s19jQrs_LJXz_ISib4DdTKPa7XTBDJlVGdCI18ctB67XwGmGi8MevkeKqFI8dkykTxeJ0MXMmEQbE6Fw-gxmP7uJYbZ61Jqwsw24zMDMeXatk2VWMBPCuhA';
+        expect(adal._createUser(TOKEN)).toBe(null);
+    });
+
+    it('verifies _createUser returns user object with userName matching the email claim contained within the id_token when no upn claim is present and a single aud claim matchint the clientId is present', function() {
+        adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';
+        var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjVUa0d0S1JrZ2FpZXpFWTJFc0xDMmdPTGpBNCJ9.eyJhdWQiOiJlOWE1YThiNi04YWY3LTQ3MTktOTgyMS0wZGVlZjI1NWY2OGUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvNTJkNGIwNzItOTQ3MC00OWZiLTg3MjEtYmMzYTFjOTkxMmExLyIsImlhdCI6MTQxMTk1OTAwMCwibmJmIjoxNDExOTU5MDAwLCJleHAiOjE0MTE5NjI5MDAsInZlciI6IjEuMCIsInRpZCI6IjUyZDRiMDcyLTk0NzAtNDlmYi04NzIxLWJjM2ExYzk5MTJhMSIsImFtciI6WyJwd2QiXSwib2lkIjoiZmEzYzVmYTctN2Q5OC00Zjk3LWJmYzQtZGJkM2E0YTAyNDMxIiwiZW1haWwiOiJ1c2VyQG9hdXRoaW1wbGljaXQuY2NzY3RwLm5ldCIsInVuaXF1ZV9uYW1lIjoidXNlckBvYXV0aGltcGxpY2l0LmNjc2N0cC5uZXQiLCJzdWIiOiJZN1RteEVjT0hTMjQ0YUdrdGNtamJyc2t2Tm1TUjhYejlfNmZtVzY1eWhnIiwiZmFtaWx5X25hbWUiOiJhIiwiZ2l2ZW5fbmFtZSI6InVzZXIiLCJub25jZSI6IjgwZmZhOTBhLWNiNzQtNGQwZi1hNGFjLWFlMWY5M2UzMmZlMCIsInB3ZF9leHAiOiI1Nzc5OTEwIiwicHdkX3VybCI6Imh0dHBzOi8vcG9ydGFsLm1pY3Jvc29mdG9ubGluZS5jb20vQ2hhbmdlUGFzc3dvcmQuYXNweCJ9.WHsl8TH1rQ3dQbRkV0TS6GBVAxzNOpG3nGG6mpEBCwAOCbyW6qRsSoo4qq8I5IGyerDf2cvcS-zzatHEROpRC9dcpwkRm6ta5dFZuouFyZ_QiYVKSMwfzEC_FI-6p7eT8gY6FbV51bp-Ah_WKJqEmaXv-lqjIpgsMGeWDgZRlB9cPODXosBq-PEk0q27Be-_A-KefQacJuWTX2eEhECLyuAu-ETVJb7s19jQrs_LJXz_ISib4DdTKPa7XTBDJlVGdCI18ctB67XwGmGi8MevkeKqFI8dkykTxeJ0MXMmEQbE6Fw-gxmP7uJYbZ61Jqwsw24zMDMeXatk2VWMBPCuhA'; 
+        expect(adal._createUser(TOKEN).userName).toBe('user@oauthimplicit.ccsctp.net');
+    });
+
+    it('verifies _createUser returns user object with userName matching the sub claim contained within the id_token when no upn and no email claim are present and a single aud claim matchint the clientId is present', function() {
+        adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';
+        var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjVUa0d0S1JrZ2FpZXpFWTJFc0xDMmdPTGpBNCJ9.eyJhdWQiOiJlOWE1YThiNi04YWY3LTQ3MTktOTgyMS0wZGVlZjI1NWY2OGUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvNTJkNGIwNzItOTQ3MC00OWZiLTg3MjEtYmMzYTFjOTkxMmExLyIsImlhdCI6MTQxMTk1OTAwMCwibmJmIjoxNDExOTU5MDAwLCJleHAiOjE0MTE5NjI5MDAsInZlciI6IjEuMCIsInRpZCI6IjUyZDRiMDcyLTk0NzAtNDlmYi04NzIxLWJjM2ExYzk5MTJhMSIsImFtciI6WyJwd2QiXSwib2lkIjoiZmEzYzVmYTctN2Q5OC00Zjk3LWJmYzQtZGJkM2E0YTAyNDMxIiwidW5pcXVlX25hbWUiOiJ1c2VyQG9hdXRoaW1wbGljaXQuY2NzY3RwLm5ldCIsInN1YiI6Ilk3VG14RWNPSFMyNDRhR2t0Y21qYnJza3ZObVNSOFh6OV82Zm1XNjV5aGciLCJmYW1pbHlfbmFtZSI6ImEiLCJnaXZlbl9uYW1lIjoidXNlciIsIm5vbmNlIjoiODBmZmE5MGEtY2I3NC00ZDBmLWE0YWMtYWUxZjkzZTMyZmUwIiwicHdkX2V4cCI6IjU3Nzk5MTAiLCJwd2RfdXJsIjoiaHR0cHM6Ly9wb3J0YWwubWljcm9zb2Z0b25saW5lLmNvbS9DaGFuZ2VQYXNzd29yZC5hc3B4In0=.WHsl8TH1rQ3dQbRkV0TS6GBVAxzNOpG3nGG6mpEBCwAOCbyW6qRsSoo4qq8I5IGyerDf2cvcS-zzatHEROpRC9dcpwkRm6ta5dFZuouFyZ_QiYVKSMwfzEC_FI-6p7eT8gY6FbV51bp-Ah_WKJqEmaXv-lqjIpgsMGeWDgZRlB9cPODXosBq-PEk0q27Be-_A-KefQacJuWTX2eEhECLyuAu-ETVJb7s19jQrs_LJXz_ISib4DdTKPa7XTBDJlVGdCI18ctB67XwGmGi8MevkeKqFI8dkykTxeJ0MXMmEQbE6Fw-gxmP7uJYbZ61Jqwsw24zMDMeXatk2VWMBPCuhA'; 
+        expect(adal._createUser(TOKEN).userName).toBe('Y7TmxEcOHS244aGktcmjbrskvNmSR8Xz9_6fmW65yhg');
+    });
+
     // TODO angular intercepptor
     // TODO angular authenticationService
 });

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -893,7 +893,8 @@ describe('Adal', function () {
             popupWindow = {
                 location: {
                     hash: VALID_URLFRAGMENT,
-                    href: 'hrefcontoso_site'
+                    href: 'hrefcontoso_site',
+                    search: ''
                 },
                 closed: false,
                 close: function () {
@@ -912,6 +913,7 @@ describe('Adal', function () {
         mathMock.random = function () {
             return 0.2;
         };
+        
         adal.login();
         waitsFor(function () {
             timercallback();
@@ -1410,6 +1412,60 @@ describe('Adal', function () {
         adal.config.clientId = 'e9a5a8b6-8af7-4719-9821-0deef255f68e';
         var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjVUa0d0S1JrZ2FpZXpFWTJFc0xDMmdPTGpBNCJ9.eyJhdWQiOiJlOWE1YThiNi04YWY3LTQ3MTktOTgyMS0wZGVlZjI1NWY2OGUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvNTJkNGIwNzItOTQ3MC00OWZiLTg3MjEtYmMzYTFjOTkxMmExLyIsImlhdCI6MTQxMTk1OTAwMCwibmJmIjoxNDExOTU5MDAwLCJleHAiOjE0MTE5NjI5MDAsInZlciI6IjEuMCIsInRpZCI6IjUyZDRiMDcyLTk0NzAtNDlmYi04NzIxLWJjM2ExYzk5MTJhMSIsImFtciI6WyJwd2QiXSwib2lkIjoiZmEzYzVmYTctN2Q5OC00Zjk3LWJmYzQtZGJkM2E0YTAyNDMxIiwidW5pcXVlX25hbWUiOiJ1c2VyQG9hdXRoaW1wbGljaXQuY2NzY3RwLm5ldCIsInN1YiI6Ilk3VG14RWNPSFMyNDRhR2t0Y21qYnJza3ZObVNSOFh6OV82Zm1XNjV5aGciLCJmYW1pbHlfbmFtZSI6ImEiLCJnaXZlbl9uYW1lIjoidXNlciIsIm5vbmNlIjoiODBmZmE5MGEtY2I3NC00ZDBmLWE0YWMtYWUxZjkzZTMyZmUwIiwicHdkX2V4cCI6IjU3Nzk5MTAiLCJwd2RfdXJsIjoiaHR0cHM6Ly9wb3J0YWwubWljcm9zb2Z0b25saW5lLmNvbS9DaGFuZ2VQYXNzd29yZC5hc3B4In0=.WHsl8TH1rQ3dQbRkV0TS6GBVAxzNOpG3nGG6mpEBCwAOCbyW6qRsSoo4qq8I5IGyerDf2cvcS-zzatHEROpRC9dcpwkRm6ta5dFZuouFyZ_QiYVKSMwfzEC_FI-6p7eT8gY6FbV51bp-Ah_WKJqEmaXv-lqjIpgsMGeWDgZRlB9cPODXosBq-PEk0q27Be-_A-KefQacJuWTX2eEhECLyuAu-ETVJb7s19jQrs_LJXz_ISib4DdTKPa7XTBDJlVGdCI18ctB67XwGmGi8MevkeKqFI8dkykTxeJ0MXMmEQbE6Fw-gxmP7uJYbZ61Jqwsw24zMDMeXatk2VWMBPCuhA'; 
         expect(adal._createUser(TOKEN).userName).toBe('Y7TmxEcOHS244aGktcmjbrskvNmSR8Xz9_6fmW65yhg');
+    });
+
+    it('verifies that isCallback returns false if both the fragment and search portions of the URL are blank', function() {
+        expect(adal.isCallback(undefined, undefined)).toBe(false);
+    });
+    
+    it('verifies that isCallback returns true if the fragment portion of the URL contains an id_token and the search portion is blank', function() {
+        var hash = '#/' + VALID_URLFRAGMENT;
+        expect(adal.isCallback(hash, undefined)).toBe(true);
+    });
+
+    it('verifies that isCallback returns true if the fragment portion of the URL is blank and the search portion contains an id_token', function() {
+        var search = '?id_token=eyJ4NXQiOiJObUptT0dVeE16WmxZak0yWkRSaE5UWmxZVEExWXpkaFpUUmlPV0UwTldJMk0ySm1PVGMxWkEiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImF1ZCI6WyJoUDdwa3JXYUJQa2NPTERaVmJsel9JZ2VtVmthIl0sImF6cCI6ImhQN3BrcldhQlBrY09MRFpWYmx6X0lnZW1Wa2EiLCJhdXRoX3RpbWUiOjE0NzU1MjI4MDksImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsInNuIjoiV29vZHdhcmQiLCJnaXZlbl9uYW1lIjoiRGF2aWQiLCJleHAiOjE0NzU1MjMxMDksIm5vbmNlIjoiNWE3MWM5ZmYtYjI1YS00YzE1LWEzNjgtNzdmODgwZWRkOWI2IiwiaWF0IjoxNDc1NTIyODA5fQ.B5KAglX92PPppP66yMkyzD1LA7qdWhrQWqYEOzJ0uFB_ZN8_u7G7Pp0qBy0Uilbh6AS0go64pzX5sxU72psHr6z2xVMJYm8-zjTb1GDVP3thUlZ1nEK-esUjSBLDnN1qKmMINtX82S3KIpAlehB1nZ94kbOHCoZ9v_k1rnTiWRA&state=6777d1e8-6014-403d-ac0c-297dec5cc514';
+        expect(adal.isCallback(undefined, search)).toBe(true);
+    });
+
+    it('verifies that isCallback returns true if the fragment portion of the URL contains a token and the search portion is blank', function() {
+        var hash = '#/access_token=4dce1d4c-3828-3873-bdda-9b2ba2726ac4&state=1120063b-8c7b-4fac-a121-a0e7e4ccb270&token_type=Bearer&expires_in=197&session_state=a41ac575b3d4c1b50acee40499a7efc1d46485913bd8520b13eebec6a657da3e.Vxrih14RiYpyTIs-X21-Pg';
+         expect(adal.isCallback(hash, undefined)).toBe(true);
+   });
+
+    it('verifies that isCallback returns true if the fragment portion of the URL contains both a token and an id_token (after embedded question mark) and the search portion is blank', function() {
+        var hash = '#/access_token=eda1a60f-4dbd-3b8c-bfce-60d3980040a5&id_token=eyJ4NXQiOiJObUptT0dVeE16WmxZak0yWkRSaE5UWmxZVEExWXpkaFpUUmlPV0UwTldJMk0ySm1PVGMxWkEiLCJhbGciOiJSUzI1NiJ9.eyJhdF9oYXNoIjoiQUI4Si1WaHlvbWxseTJBbktvN2dVUSIsInN1YiI6ImFkbWluIiwiYXVkIjpbImhQN3BrcldhQlBrY09MRFpWYmx6X0lnZW1Wa2EiXSwiYXpwIjoiaFA3cGtyV2FCUGtjT0xEWlZibHpfSWdlbVZrYSIsImF1dGhfdGltZSI6MTQ3NTUyMjUyMCwiaXNzIjoiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rva2VuIiwic24iOiJXb29kd2FyZCIsImdpdmVuX25hbWUiOiJEYXZpZCIsImV4cCI6MTQ3NTUyMjgyMCwibm9uY2UiOiI1NTRkMjE5Ny0yYTQzLTQzMGUtOGJmNy1kMjk5MTIxNjE5MDEiLCJpYXQiOjE0NzU1MjI1MjB9.WrTgmLsBuP6BG1v1aBs4dp3ONYEtuzlUySsG4ImpAVIBg9BJv_nc9NPDSK_IMxiKi7sHwJWzCzNLHUbOkmmZxTqIQt7KEs_Kx2ZBlf_Yvb_YPyAcUasBlX4BzHLq0nOAqax43fgholLLXPA4WZmBkDVw6piquPQ45uCJ8_Myezs&state=e60a53f8-fadc-477a-b51d-64e7c31b06e9&token_type=Bearer&expires_in=300&session_state=8cbc061a22547adff4c5f88a80de8999129997b8ff7c7c66c870a43d6d2a2d6a.enxHcp7nDHTPhFPWaY-l4g';
+         expect(adal.isCallback(hash, undefined)).toBe(true);
+   });
+
+    it('verifies that _getParameters returns an empty object if both the fragment and search portions of the URL are blank', function() {
+        expect(Object.getOwnPropertyNames(adal._getParameters(undefined, undefined)).length).toBe(0);
+    });
+
+    it('verifies that _getParameters returns an object containing the id_token when the fragment portion of the URL is blank and the search portion of the URL contains the id_token', function() {
+        var TOKEN = 'eyJ4NXQiOiJObUptT0dVeE16WmxZak0yWkRSaE5UWmxZVEExWXpkaFpUUmlPV0UwTldJMk0ySm1PVGMxWkEiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImF1ZCI6WyJoUDdwa3JXYUJQa2NPTERaVmJsel9JZ2VtVmthIl0sImF6cCI6ImhQN3BrcldhQlBrY09MRFpWYmx6X0lnZW1Wa2EiLCJhdXRoX3RpbWUiOjE0NzU1MjI4MDksImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsInNuIjoiV29vZHdhcmQiLCJnaXZlbl9uYW1lIjoiRGF2aWQiLCJleHAiOjE0NzU1MjMxMDksIm5vbmNlIjoiNWE3MWM5ZmYtYjI1YS00YzE1LWEzNjgtNzdmODgwZWRkOWI2IiwiaWF0IjoxNDc1NTIyODA5fQ.B5KAglX92PPppP66yMkyzD1LA7qdWhrQWqYEOzJ0uFB_ZN8_u7G7Pp0qBy0Uilbh6AS0go64pzX5sxU72psHr6z2xVMJYm8-zjTb1GDVP3thUlZ1nEK-esUjSBLDnN1qKmMINtX82S3KIpAlehB1nZ94kbOHCoZ9v_k1rnTiWRA';
+        var search = '?id_token=' + TOKEN + '&state=6777d1e8-6014-403d-ac0c-297dec5cc514';
+        expect(adal._getParameters(undefined, search).id_token).toBe(TOKEN);
+    });
+
+    it('verifies that _getParameters returns an object containing the token when the fragment porion of the URL contains the access_token and the search portion of the URL is blank', function() {
+        var TOKEN = '4dce1d4c-3828-3873-bdda-9b2ba2726ac4';
+        var hash = '#/access_token=' + TOKEN + '&state=1120063b-8c7b-4fac-a121-a0e7e4ccb270&token_type=Bearer&expires_in=197&session_state=a41ac575b3d4c1b50acee40499a7efc1d46485913bd8520b13eebec6a657da3e.Vxrih14RiYpyTIs-X21-Pg';
+        expect(adal._getParameters(hash, undefined).access_token).toBe(TOKEN);
+    });
+
+    it('verifies that _getParameters returns an object containing the token when the fragment portion of the URL contains the id_token and the search portion of the URL is blank.', function() {
+        var hash = '#/' + VALID_URLFRAGMENT;
+        expect(adal._getParameters(hash, undefined).id_token).toBe(IDTOKEN_MOCK);
+    });
+
+    it('', function() {
+        var ID_TOKEN = 'eyJ4NXQiOiJObUptT0dVeE16WmxZak0yWkRSaE5UWmxZVEExWXpkaFpUUmlPV0UwTldJMk0ySm1PVGMxWkEiLCJhbGciOiJSUzI1NiJ9.eyJhdF9oYXNoIjoiQUI4Si1WaHlvbWxseTJBbktvN2dVUSIsInN1YiI6ImFkbWluIiwiYXVkIjpbImhQN3BrcldhQlBrY09MRFpWYmx6X0lnZW1Wa2EiXSwiYXpwIjoiaFA3cGtyV2FCUGtjT0xEWlZibHpfSWdlbVZrYSIsImF1dGhfdGltZSI6MTQ3NTUyMjUyMCwiaXNzIjoiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rva2VuIiwic24iOiJXb29kd2FyZCIsImdpdmVuX25hbWUiOiJEYXZpZCIsImV4cCI6MTQ3NTUyMjgyMCwibm9uY2UiOiI1NTRkMjE5Ny0yYTQzLTQzMGUtOGJmNy1kMjk5MTIxNjE5MDEiLCJpYXQiOjE0NzU1MjI1MjB9.WrTgmLsBuP6BG1v1aBs4dp3ONYEtuzlUySsG4ImpAVIBg9BJv_nc9NPDSK_IMxiKi7sHwJWzCzNLHUbOkmmZxTqIQt7KEs_Kx2ZBlf_Yvb_YPyAcUasBlX4BzHLq0nOAqax43fgholLLXPA4WZmBkDVw6piquPQ45uCJ8_Myezs';
+        var ACCESS_TOKEN = 'eda1a60f-4dbd-3b8c-bfce-60d3980040a5';
+        var hash = '#/access_token=' + ACCESS_TOKEN + '&id_token=' + ID_TOKEN + '&state=e60a53f8-fadc-477a-b51d-64e7c31b06e9&token_type=Bearer&expires_in=300&session_state=8cbc061a22547adff4c5f88a80de8999129997b8ff7c7c66c870a43d6d2a2d6a.enxHcp7nDHTPhFPWaY-l4g';
+        var parameters = adal._getParameters(hash, undefined);
+        expect(parameters.id_token).toBe(ID_TOKEN);
+        expect(parameters.access_token).toBe(ACCESS_TOKEN);
     });
 
     // TODO angular intercepptor

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -881,6 +881,7 @@ describe('Adal', function () {
 
     it('tests login functionality in case of popup window', function () {
         var timercallback;
+        window.location = { search: undefined };
         window.clearInterval = function () {
         };
         window.setInterval = function (method, timer) {
@@ -895,7 +896,7 @@ describe('Adal', function () {
                 location: {
                     hash: VALID_URLFRAGMENT,
                     href: 'hrefcontoso_site',
-                    search: ''
+                    search: undefined
                 },
                 closed: false,
                 close: function () {


### PR DESCRIPTION
Enhanced library to allow for other OpenIDConnect identity providers by supporting blank tenant and custom root context values in the instance URL and optional scope and response type parameters.  Also allowed for the ID_TOKEN to be returned as a URL query parameter rather than a URL fragment.  Finally, added the necessary tests to verify the various scenarios around this functionality.

Closes #409 