### PR TITLE
full multi-tenant support

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1,4 +1,4 @@
-//----------------------------------------------------------------------
+﻿//----------------------------------------------------------------------
 // AdalJS v1.0.13
 // @preserve Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
@@ -37,6 +37,7 @@ var AuthenticationContext = (function () {
      *  @property {Array.<string>} anonymousEndpoints Array of keywords or URI's. Adal will not attach a token to outgoing requests that have these keywords or uri. Defaults to 'null'.
      *  @property {number} expireOffsetSeconds If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 120 seconds.
      *  @property {string} correlationId Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
+     *  @property {Boolean} multiTenant - Support multi-tenant resource tokens.
      */
 
     /**
@@ -83,6 +84,7 @@ var AuthenticationContext = (function () {
                 RENEW_STATUS: 'adal.token.renew.status'
             },
             RESOURCE_DELIMETER: '|',
+            RESOURCE_TENANT_JOIN_DELIMETER: '$',
             LOADFRAME_TIMEOUT: '6000',
             TOKEN_RENEW_STATUS_CANCELED: 'Canceled',
             TOKEN_RENEW_STATUS_COMPLETED: 'Completed',
@@ -114,6 +116,7 @@ var AuthenticationContext = (function () {
         this.callback = null;
         this.popUp = false;
         this.isAngular = false;
+        this.multiTenant = false;
 
         // private
         this._user = null;
@@ -160,6 +163,10 @@ var AuthenticationContext = (function () {
 
         if (this.config.isAngular) {
             this.isAngular = this.config.isAngular;
+        }
+
+        if (this.config.multiTenant) {
+            this.multiTenant = true;
         }
     };
 
@@ -298,16 +305,16 @@ var AuthenticationContext = (function () {
 
     /**
      * Gets token for the specified resource from the cache.
-     * @param {string}   resource A URI that identifies the resource for which the token is requested.
+     * @param {string}   id A URI that identifies the resource for which the token is requested.
      * @returns {string} token if if it exists and not expired, otherwise null.
      */
-    AuthenticationContext.prototype.getCachedToken = function (resource) {
-        if (!this._hasResource(resource)) {
+    AuthenticationContext.prototype.getCachedToken = function (id) {
+        if (!this._hasResource(id)) {
             return null;
         }
 
-        var token = this._getItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource);
-        var expired = this._getItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource);
+        var token = this._getItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + id);
+        var expired = this._getItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + id);
 
         // If expiration is within offset, it will force renew
         var offset = this.config.expireOffsetSeconds || 120;
@@ -315,8 +322,8 @@ var AuthenticationContext = (function () {
         if (expired && (expired > this._now() + offset)) {
             return token;
         } else {
-            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, '');
-            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, 0);
+            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + id, '');
+            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + id, 0);
             return null;
         }
     };
@@ -344,12 +351,35 @@ var AuthenticationContext = (function () {
   
     /**
      * Adds the passed callback to the array of callbacks for the specified resource and puts the array on the window object. 
-     * @param {string}   resource A URI that identifies the resource for which the token is requested.
      * @param {string}   expectedState A unique identifier (guid).
+     * @param {string}   resource A URI that identifies the resource for which the token is requested.
      * @param {tokenCallback} callback - The callback provided by the caller. It will be called with token or error.
      */
     AuthenticationContext.prototype.registerCallback = function (expectedState, resource, callback) {
-        this._activeRenewals[resource] = expectedState;
+        return this._registerCallbackWithTenantCommon(expectedState, resource, this.config.tenant, callback);
+    };
+
+    /**
+     * Adds the passed callback to the array of callbacks for the specified resource and puts the array on the window object. 
+     * @param {string}   expectedState A unique identifier (guid).
+     * @param {string}   resource A URI that identifies the resource for which the token is requested.
+     * @param {string}   tenantId The tenant for the resource.
+     * @param {tokenCallback} callback - The callback provided by the caller. It will be called with token or error.
+     */
+    AuthenticationContext.prototype.registerCallbackWithTenant = function (expectedState, resource, tenantId, callback) {
+        if (!this.multiTenant) {
+            throw new Error('Multi-Tenant support is disabled! Set config.multiTenant = true to enable support.');
+        }
+        return this._registerCallbackWithTenantCommon(expectedState, resource, tenantId, callback);
+    };
+
+    /**
+     * Adds the passed callback to the array of callbacks for the specified resource and puts the array on the window object. 
+     * @ignore
+     */
+    AuthenticationContext.prototype._registerCallbackWithTenantCommon = function (expectedState, resource, tenantId, callback) {
+        var id = this._buildIdFromResourceAndTenant(resource, tenantId);
+        this._activeRenewals[id] = expectedState;
         if (!window.callBacksMappedToRenewStates[expectedState]) {
             window.callBacksMappedToRenewStates[expectedState] = [];
         }
@@ -365,7 +395,7 @@ var AuthenticationContext = (function () {
                         self.warn(error);
                     }
                 }
-                self._activeRenewals[resource] = null;
+                self._activeRenewals[id] = null;
                 window.callBacksMappedToRenewStates[expectedState] = null;
                 window.callBackMappedToRenewStates[expectedState] = null;
             };
@@ -381,24 +411,33 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._renewToken = function (resource, callback) {
+        return this._renewTokenForTenant(resource, this.config.tenant, callback);
+    };
+
+    /**
+     * Acquires access token with hidden iframe
+     * @ignore
+     */
+    AuthenticationContext.prototype._renewTokenForTenant = function (resource, tenantId, callback) {
         // use iframe to try refresh token
         // use given resource to create new authz url
-        this.info('renewToken is called for resource:' + resource);
-        var frameHandle = this._addAdalFrame('adalRenewFrame' + resource);
-        var expectedState = this._guid() + '|' + resource;
+        var newResource = this._buildIdFromResourceAndTenant(resource, tenantId);
+        this.info('renewToken is called for resource:' + newResource);
+        var frameHandle = this._addAdalFrame('adalRenewFrame' + newResource);
+        var expectedState = this._guid() + this.CONSTANTS.RESOURCE_DELIMETER + newResource;
         this.config.state = expectedState;
         // renew happens in iframe, so it keeps javascript context
         this._renewStates.push(expectedState);
 
         this.verbose('Renew token Expected state: ' + expectedState);
-        var urlNavigate = this._getNavigateUrl('token', resource) + '&prompt=none';
+        var urlNavigate = this._getNavigateUrl('token', resource, tenantId) + '&prompt=none';
+
         urlNavigate = this._addHintParameters(urlNavigate);
 
-        this.registerCallback(expectedState, resource, callback);
+        this._registerCallbackWithTenantCommon(expectedState, resource, tenantId, callback);
         this.verbose('Navigate to:' + urlNavigate);
         frameHandle.src = 'about:blank';
-        this._loadFrameTimeout(urlNavigate, 'adalRenewFrame' + resource, resource);
-
+        this._loadFrameTimeout(urlNavigate, 'adalRenewFrame' + newResource, newResource);
     };
 
     /**
@@ -409,7 +448,7 @@ var AuthenticationContext = (function () {
         // use iframe to try refresh token
         this.info('renewIdToken is called');
         var frameHandle = this._addAdalFrame('adalIdTokenFrame');
-        var expectedState = this._guid() + '|' + this.config.clientId;
+        var expectedState = this._guid() + this.CONSTANTS.RESOURCE_DELIMETER + this.config.clientId;
         this._idTokenNonce = this._guid();
         this._saveItem(this.CONSTANTS.STORAGE.NONCE_IDTOKEN, this._idTokenNonce);
         this.config.state = expectedState;
@@ -494,20 +533,38 @@ var AuthenticationContext = (function () {
      * @param {tokenCallback} callback -  The callback provided by the caller. It will be called with token or error.
      */
     AuthenticationContext.prototype.acquireToken = function (resource, callback) {
+        return this._acquireTokenCommon(resource, resource, this._getDefaultTenantId(), callback);
+    };
+
+    /**
+     * Acquires token from the cache if it is not expired. Otherwise sends request to AAD to obtain a new token.
+     * @param {string}   resource -  ResourceUri identifying the target resource
+     * @param {string}   tenantId -  Tenant id for which the token should be acquired
+     * @param {tokenCallback} callback -  The callback provided by the caller. It will be called with token or error.
+     */
+    AuthenticationContext.prototype.acquireTokenForTenant = function (resource, tenantId, callback) {
+        if (!this.multiTenant) {
+            throw new Error('Multi-Tenant support is disabled! Set config.multiTenant = true to enable support.');
+        }
+        var id = this._buildIdFromResourceAndTenant(resource, tenantId);
+        return this._acquireTokenCommon(id, resource, tenantId, callback);
+    }
+
+    AuthenticationContext.prototype._acquireTokenCommon = function (id, resource, tenantId, callback) {
         if (this._isEmpty(resource)) {
             this.warn('resource is required');
             callback('resource is required', null, 'resource is required');
             return;
         }
 
-        var token = this.getCachedToken(resource);
+        var token = this.getCachedToken(id);
         if (token) {
-            this.info('Token is already in cache for resource:' + resource);
+            this.info('Token is already in cache for resource:' + resource + " , tenant: " + tenantId);
             callback(null, token, null);
             return;
         }
 
-        if (!this._user) {
+        if (!this.getCachedUser()) {
             this.warn('User login is required');
             callback('User login is required', null, 'login required');
             return;
@@ -515,9 +572,9 @@ var AuthenticationContext = (function () {
 
         // refresh attept with iframe
         //Already renewing for this resource, callback when we get the token.
-        if (this._activeRenewals[resource]) {
+        if (this._activeRenewals[id]) {
             //Active renewals contains the state for each renewal.
-            this.registerCallback(this._activeRenewals[resource], resource, callback);
+            this.registerCallback(this._activeRenewals[id], resource, callback);
         }
         else {
             if (resource === this.config.clientId) {
@@ -526,7 +583,7 @@ var AuthenticationContext = (function () {
                 this.verbose('renewing idtoken');
                 this._renewIdToken(callback);
             } else {
-                this._renewToken(resource, callback);
+                this._renewTokenForTenant(resource, tenantId, callback);
             }
         }
     };
@@ -577,9 +634,16 @@ var AuthenticationContext = (function () {
         this._saveItem(this.CONSTANTS.STORAGE.STATE_RENEW, '');
         this._saveItem(this.CONSTANTS.STORAGE.ERROR, '');
         this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, '');
-        if (this._hasResource(resource)) {
-            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, '');
-            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, 0);
+
+        var keysList = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS);
+        if (!this._isEmpty(keysList)) {
+            var keys = keysList.split(this.CONSTANTS.RESOURCE_DELIMETER);
+            for (var i = 0; i < keys.length; i++) {
+                if (keys[i].indexOf(resource) > -1) {
+                    this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + keys[i], '');
+                    this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + keys[i], 0);
+                }
+            }
         }
     };
 
@@ -612,6 +676,7 @@ var AuthenticationContext = (function () {
         this.info('Logout navigate to: ' + urlNavigate);
         this.promptUser(urlNavigate);
     };
+
 
     AuthenticationContext.prototype._isEmpty = function (str) {
         return (typeof str === 'undefined' || !str || 0 === str.length);
@@ -786,10 +851,17 @@ var AuthenticationContext = (function () {
 
                 // async calls can fire iframe and login request at the same time if developer does not use the API as expected
                 // incoming callback needs to be looked up to find the request type
-                if (stateResponse === this._getItem(this.CONSTANTS.STORAGE.STATE_LOGIN)) {
-                    requestInfo.requestType = this.REQUEST_TYPE.LOGIN;
-                    requestInfo.stateMatch = true;
-                    return requestInfo;
+                switch (stateResponse) {
+                    case this._getItem(this.CONSTANTS.STORAGE.STATE_LOGIN):
+                        requestInfo.requestType = this.REQUEST_TYPE.LOGIN;
+                        requestInfo.stateMatch = true;
+                        break;
+
+                    case this._getItem(this.CONSTANTS.STORAGE.STATE_IDTOKEN):
+                        requestInfo.requestType = this.REQUEST_TYPE.ID_TOKEN;
+                        this._saveItem(this.CONSTANTS.STORAGE.STATE_IDTOKEN, '');
+                        requestInfo.stateMatch = true;
+                        break;
                 }
 
                 // external api requests may have many renewtoken requests for different resource
@@ -815,7 +887,7 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype._getResourceFromState = function (state) {
         if (state) {
-            var splitIndex = state.indexOf('|');
+            var splitIndex = state.indexOf(this.CONSTANTS.RESOURCE_DELIMETER);
             if (splitIndex > -1 && splitIndex + 1 < state.length) {
                 return state.substring(splitIndex + 1);
             }
@@ -833,6 +905,11 @@ var AuthenticationContext = (function () {
         this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, '');
 
         var resource = this._getResourceFromState(requestInfo.stateResponse);
+
+        var id = resource;
+        if (this.multiTenant) {
+            id = requestInfo.parameters.state;
+        }
 
         // Record error
         if (requestInfo.parameters.hasOwnProperty(this.CONSTANTS.ERROR_DESCRIPTION)) {
@@ -858,13 +935,14 @@ var AuthenticationContext = (function () {
                 if (requestInfo.parameters.hasOwnProperty(this.CONSTANTS.ACCESS_TOKEN)) {
                     this.info('Fragment has access token');
 
-                    if (!this._hasResource(resource)) {
+                    if (!this._hasResource(id)) {
                         keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
-                        this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + resource + this.CONSTANTS.RESOURCE_DELIMETER);
+                        this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + id + this.CONSTANTS.RESOURCE_DELIMETER);
                     }
-                    // save token with related resource
-                    this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN]);
-                    this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, this._expiresIn(requestInfo.parameters[this.CONSTANTS.EXPIRES_IN]));
+
+                    // save token with related state
+                    this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + id, requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN]);
+                    this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + id, this._expiresIn(requestInfo.parameters[this.CONSTANTS.EXPIRES_IN]));
                 }
 
                 if (requestInfo.parameters.hasOwnProperty(this.CONSTANTS.ID_TOKEN)) {
@@ -887,8 +965,8 @@ var AuthenticationContext = (function () {
                                 keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) || '';
                                 this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, keys + resource + this.CONSTANTS.RESOURCE_DELIMETER);
                             }
-                            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
-                            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, this._user.profile.exp);
+                            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + id, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
+                            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + id, this._user.profile.exp);
                         }
                     }
                     else {
@@ -993,10 +1071,9 @@ var AuthenticationContext = (function () {
      * Constructs the authorization endpoint URL and returns it.
      * @ignore
      */
-    AuthenticationContext.prototype._getNavigateUrl = function (responseType, resource) {
-        var tenant = 'common';
-        if (this.config.tenant) {
-            tenant = this.config.tenant;
+    AuthenticationContext.prototype._getNavigateUrl = function (responseType, resource, tenant) {
+        if (!tenant) {
+            tenant = this._getDefaultTenantId();
         }
 
         var urlNavigate = this.instance + tenant + '/oauth2/authorize' + this._serialize(responseType, this.config, resource) + this._addLibMetadata();
@@ -1360,6 +1437,18 @@ var AuthenticationContext = (function () {
         }
 
         return sessionStorage.getItem(key);
+    };
+
+    AuthenticationContext.prototype._getDefaultTenantId = function () {
+
+        return this.config.tenant || "common";
+    };
+
+    AuthenticationContext.prototype._buildIdFromResourceAndTenant = function (resource, tenantId) {
+        if (this.multiTenant) {
+            return resource + this.CONSTANTS.RESOURCE_TENANT_JOIN_DELIMETER + tenantId;
+        }
+        return resource;
     };
 
     /**


### PR DESCRIPTION
The existing token aquisition does not separate tokens, for the same
resource from different tenants, in the storage or the internal state.

The goal for these changes was to leave existing usage unchanged in
behavior and functionality.

To achieve that a new bool was added to the config `config.multiTenant` This flag defaults to false.

When that flag is true, a new public method can be used to
simultaneously request resource tokens from as many tenants as wanted.
`acquireTokenForTenant(resource, tenantId, callback)`

There is also a new method available to register callbacks
`registerCallbackWithTenant(expectedState, resource, tenantId, callback)`

Credit to Rajesh Babu Srikakollu for these changes