### PR TITLE
Updates adal to return token via acquireToken when token is not cached.

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -520,6 +520,15 @@ var AuthenticationContext = (function () {
             this.registerCallback(this._activeRenewals[resource], resource, callback);
         }
         else {
+            this.storageChangeEventListener = this._callbackWithTokenOnStorageChange.bind(this, resource);
+
+            if (window.addEventListener) {
+                window.addEventListener('storage', this.storageChangeEventListener, false);
+            }
+            else if (window.attachEvent) {
+                window.attachEvent('onstorage', this.storageChangeEventListener, false);
+            }
+            
             if (resource === this.config.clientId) {
                 // App uses idtoken to send to api endpoints
                 // Default resource is tracked as clientid to store this token
@@ -530,6 +539,28 @@ var AuthenticationContext = (function () {
             }
         }
     };
+
+    /**
+     * Is responsible for calling back with the requested token (after the iframe fetches the token).
+     * @param resource
+     * @private
+     */
+    AuthenticationContext.prototype._callbackWithTokenOnStorageChange = function(resource) {
+        var expectedState = this._activeRenewals[resource];
+        if (expectedState && window.callBackMappedToRenewStates[expectedState]) {
+            var token = this.getCachedToken(resource);
+            if (token) {
+                window.callBackMappedToRenewStates[expectedState](null, token);
+
+                if (window.removeEventListener) {
+                    window.removeEventListener('storage', this.storageChangeEventListener);
+                }
+                else if (window.detachEvent) {
+                    window.detachEvent('onstorage', this.storageChangeEventListener);
+                }
+            }
+        }
+    }
 
     /**
      * Redirects the browser to Azure AD authorization endpoint.


### PR DESCRIPTION
The problem is that acquireToken does not return the new token after creating a new iframe (and the iframe fetches the token). It seems reasonable that when a caller calls acquireToken they will get the token back in the callback.

Solution: before creating the iframe, watch localStorage for changes. When changes are detected, check if there is a valid cached token and if there is, call back with the new token. 

Fixes #446 