### PR TITLE
Rename variable for clarity

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -307,12 +307,12 @@ var AuthenticationContext = (function () {
         }
 
         var token = this._getItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource);
-        var expired = this._getItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource);
+        var expiry = this._getItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource);
 
         // If expiration is within offset, it will force renew
         var offset = this.config.expireOffsetSeconds || 120;
 
-        if (expired && (expired > this._now() + offset)) {
+        if (expiry && (expiry > this._now() + offset)) {
             return token;
         } else {
             this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, '');


### PR DESCRIPTION
Make it more clear that the variable is the expiration time, and not if it is expired or not.