### PR TITLE
pass event from locationChangeHandler to processhash

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -75,7 +75,7 @@
                     else {
                         var hash = '#' + $location.path();
                     }
-                    processHash(hash);
+                    processHash(hash, event);
 
                     $timeout(function () {
                         updateDataFromCache(_adal.config.loginResource);
@@ -83,7 +83,7 @@
                     }, 1);
                 };
 
-                var processHash = function (hash) {
+                var processHash = function (hash, event) {
                     if (_adal.isCallback(hash)) {
                         // callback can come from login or iframe request
                         _adal.verbose('Processing the hash: ' + hash);
@@ -94,7 +94,9 @@
                             if (requestInfo.requestType === _adal.REQUEST_TYPE.RENEW_TOKEN) {
                                 var callback = $window.parent.callBackMappedToRenewStates[requestInfo.stateResponse];
                                 // since this is a token renewal request in iFrame, we don't need to proceed with the location change.
-                                event.preventDefault();
+                                if (event && event.preventDefault) {
+                                    event.preventDefault();
+                                }
 
                                 // Call within the same context without full page redirect keeps the callback
                                 if (callback && typeof callback === 'function') {


### PR DESCRIPTION
the event variable is not defined anymore in the processhash function and therefore the call to event.preventDefault fails and the following callback will never be executed.

