### PR TITLE
UPN-less accounts can silent reauthenticate

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -670,14 +670,15 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
         // include hint params only if upn is present
-        if (this._user && this._user.profile && this._user.profile.hasOwnProperty('upn')) {
+        if (this._user && this._user.profile && (this._user.profile.hasOwnProperty('upn') || this._user.profile.hasOwnProperty('email'))) {
 
             // add login_hint
-            urlNavigate += '&login_hint=' + encodeURIComponent(this._user.profile.upn);
+            var loginHint = this._user.profile.hasOwnProperty('upn') ? this._user.profile.upn : this._user.profile.email;
+            urlNavigate += '&login_hint=' + encodeURIComponent(loginHint);
 
             // don't add domain_hint twice if user provided it in the extraQueryParameter value
-            if (!this._urlContainsQueryStringParameter("domain_hint", urlNavigate) && this._user.profile.upn.indexOf('@') > -1) {
-                var parts = this._user.profile.upn.split('@');
+            if (!this._urlContainsQueryStringParameter("domain_hint", urlNavigate) && loginHint.indexOf('@') > -1) {
+                var parts = loginHint.split('@');
                 // local part can include @ in quotes. Sending last part handles that.
                 urlNavigate += '&domain_hint=' + encodeURIComponent(parts[parts.length - 1]);
             }


### PR DESCRIPTION
We found for certain accounts that do not have a UPN they could not silently authenticate within the iframe without the login_hint being provided.