### PR TITLE
Only redirect to original url in case of login req

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1002,7 +1002,7 @@ var AuthenticationContext = (function () {
             }
             if (!this.popUp) {
                 window.location.hash = '';
-                if (this.config.navigateToLoginRequestUrl && window.location.href.replace('#', '') !== this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST))
+                if (this.config.navigateToLoginRequestUrl && window.location.href.replace('#', '') !== this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST) && requestInfo.requestType === this.REQUEST_TYPE.LOGIN)
                     window.location.href = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
             }
         }


### PR DESCRIPTION
Redirection to the original page that was saved to storage before initiating the login should only happen when handling a login request. If the target page performs API calls, and the redirect is also performed when handling token renewals, this results in decreased performance due to the API calls being fired multiple times.