### PR TITLE
Add domain_hint optional feature to login

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -37,6 +37,7 @@ var AuthenticationContext = (function () {
      *  @property {Array.<string>} anonymousEndpoints Array of keywords or URI's. Adal will not attach a token to outgoing requests that have these keywords or uri. Defaults to 'null'.
      *  @property {number} expireOffsetSeconds If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 120 seconds.
      *  @property {string} correlationId Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
+     *  @property {string} domainHint - Optional - This value can be consumers or organizations. If included, it skips the email-based discovery process that the user goes through on the v2.0 sign-in page, for a slightly more streamlined user experience.   https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oidc
      */
 
     /**
@@ -672,7 +673,7 @@ var AuthenticationContext = (function () {
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
         // include domain hint if provided by the config
         if (this.config.domainhint) {
-             urlNavigate += '&domain_hint=' + encodeURIComponent(this.config.domainhint);
+             urlNavigate += '&domain_hint=' + encodeURIComponent(this.config.domainHint);
         }
 
         // include hint params only if upn is present

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -672,7 +672,7 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
         // include domain hint if provided by the config
-        if (this.config.domainhint) {
+        if (this.config.domainHint) {
              urlNavigate += '&domain_hint=' + encodeURIComponent(this.config.domainHint);
         }
 

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -198,6 +198,7 @@ var AuthenticationContext = (function () {
         this._saveItem(this.CONSTANTS.STORAGE.ERROR, '');
         this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, '');
         var urlNavigate = this._getNavigateUrl('id_token', null) + '&nonce=' + encodeURIComponent(this._idTokenNonce);
+        urlNavigate = this._addHintParameters(urlNavigate);
         this._loginInProgress = true;
         if (this.config.displayCall) {
             // User defined way of handling the navigation
@@ -669,6 +670,11 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
+        // include domain hint if provided by the config
+        if (this.config.domainhint) {
+             urlNavigate += '&domain_hint=' + encodeURIComponent(this.config.domainhint);
+        }
+
         // include hint params only if upn is present
         if (this._user && this._user.profile && this._user.profile.hasOwnProperty('upn')) {
 


### PR DESCRIPTION
Added a Config option "domainHint" that will allow provide the domain_hint optional parameter when initially authenticating via ADAL. 

> This value can be consumers or organizations. If included, it skips the email-based discovery process that the user goes through on the v2.0 sign-in page, for a slightly more streamlined user experience.

https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols-oidc

to use the feature via the config 

adalAuthenticationServiceProvider.init(
        {
            // Config to specify endpoints and similar for your app
            tenant: "52d4b072-9470-49fb-8721-bc3a1c9912a1", // Optional by default, it sends common
            clientId: "e9a5a8b6-8af7-4719-9821-0deef255f68e", // Required
            //localLoginUrl: "/login",  // optional
            //redirectUri : "your site", optional
            domainHint: "organizations" // optional, value can be consumers or organizations
            
        },