### PR TITLE
Persist loginInProgress in sessionStorage to prevent duplicate login

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -299,7 +299,7 @@ var AuthenticationContext = (function () {
             return loginInProgress;
 		}
 
-        return this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) === 'true';
+        return this._getItem(this.CONSTANTS.STORAGE.LOGIN_INPROGRESS) === 'true';
     };
 
     /**

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -296,6 +296,7 @@ var AuthenticationContext = (function () {
     AuthenticationContext.prototype.loginInProgress = function (loginInProgress) {
 		if(typeof(loginInProgress) === 'boolean') {
 			this._setItem(this.CONSTANTS.STORAGE.LOGIN_INPROGRESS, loginInProgress);
+            return loginInProgress;
 		}
 
         return this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) === 'true';

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -78,6 +78,7 @@ var AuthenticationContext = (function () {
                 IDTOKEN: 'adal.idtoken',
                 ERROR: 'adal.error',
                 ERROR_DESCRIPTION: 'adal.error.description',
+                LOGIN_INPROGRESS: 'adal.login.inprogress',
                 LOGIN_REQUEST: 'adal.login.request',
                 LOGIN_ERROR: 'adal.login.error',
                 RENEW_STATUS: 'adal.token.renew.status'
@@ -118,7 +119,6 @@ var AuthenticationContext = (function () {
         // private
         this._user = null;
         this._activeRenewals = {};
-        this._loginInProgress = false;
         this._renewStates = [];
 
         window.callBackMappedToRenewStates = {};
@@ -183,7 +183,7 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype.login = function (loginStartPage) {
         // Token is not present and user needs to login
-        if (this._loginInProgress) {
+        if (this.loginInProgress()) {
             this.info("Login in progress");
             return;
         }
@@ -198,7 +198,7 @@ var AuthenticationContext = (function () {
         this._saveItem(this.CONSTANTS.STORAGE.ERROR, '');
         this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, '');
         var urlNavigate = this._getNavigateUrl('id_token', null) + '&nonce=' + encodeURIComponent(this._idTokenNonce);
-        this._loginInProgress = true;
+        this.loginInProgress(true);
         if (this.config.displayCall) {
             // User defined way of handling the navigation
             this.config.displayCall(urlNavigate);
@@ -239,7 +239,7 @@ var AuthenticationContext = (function () {
             return popupWindow;
         } catch (e) {
             this.warn('Error opening popup, ' + e.message);
-            this._loginInProgress = false;
+            this.loginInProgress(false);
             return null;
         }
     }
@@ -267,7 +267,7 @@ var AuthenticationContext = (function () {
         var that = this;
         var pollTimer = window.setInterval(function () {
             if (!popupWindow || popupWindow.closed || popupWindow.closed === undefined) {
-                that._loginInProgress = false;
+                that.loginInProgress(false);
                 window.clearInterval(pollTimer);
             }
             try {
@@ -279,7 +279,7 @@ var AuthenticationContext = (function () {
                         that.handleWindowCallback(popupWindow.location.hash);
                     }
                     window.clearInterval(pollTimer);
-                    that._loginInProgress = false;
+                    that.loginInProgress(false);
                     that.info("Closing popup window");
                     popupWindow.close();
                 }
@@ -293,8 +293,12 @@ var AuthenticationContext = (function () {
         window.dispatchEvent(evt);
     };
 
-    AuthenticationContext.prototype.loginInProgress = function () {
-        return this._loginInProgress;
+    AuthenticationContext.prototype.loginInProgress = function (loginInProgress) {
+		if(typeof(loginInProgress) === 'boolean') {
+			this._setItem(this.CONSTANTS.STORAGE.LOGIN_INPROGRESS, loginInProgress);
+		}
+
+        return this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS) === 'true';
     };
 
     /**
@@ -853,7 +857,7 @@ var AuthenticationContext = (function () {
             this._saveItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION, requestInfo.parameters[this.CONSTANTS.ERROR_DESCRIPTION]);
 
             if (requestInfo.requestType === this.REQUEST_TYPE.LOGIN) {
-                this._loginInProgress = false;
+                this.loginInProgress(false);
                 this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, requestInfo.parameters.error_description);
             }
         } else {
@@ -881,7 +885,7 @@ var AuthenticationContext = (function () {
 
                 if (requestInfo.parameters.hasOwnProperty(this.CONSTANTS.ID_TOKEN)) {
                     this.info('Fragment has id token');
-                    this._loginInProgress = false;
+                    this.loginInProgress(false);
 
                     this._user = this._createUser(requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
 

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -295,7 +295,7 @@ var AuthenticationContext = (function () {
 
     AuthenticationContext.prototype.loginInProgress = function (loginInProgress) {
 		if(typeof(loginInProgress) === 'boolean') {
-			this._setItem(this.CONSTANTS.STORAGE.LOGIN_INPROGRESS, loginInProgress);
+			this._saveItem(this.CONSTANTS.STORAGE.LOGIN_INPROGRESS, loginInProgress);
             return loginInProgress;
 		}
 


### PR DESCRIPTION
When there are multiple instances of adal running in the same webpage (f.e. iFrames) multiple login requests can be invoked.