### PR TITLE
Pass in event to be able to call preventDefault

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -75,7 +75,7 @@
                     else {
                         var hash = '#' + $location.path();
                     }
-                    processHash(hash);
+                    processHash(event, hash);
 
                     $timeout(function () {
                         updateDataFromCache(_adal.config.loginResource);
@@ -83,7 +83,7 @@
                     }, 1);
                 };
 
-                var processHash = function (hash) {
+                var processHash = function (event, hash) {
                     if (_adal.isCallback(hash)) {
                         // callback can come from login or iframe request
                         _adal.verbose('Processing the hash: ' + hash);
@@ -304,7 +304,7 @@
 
                 //Event to track hash change of 
                 $window.addEventListener('adal:popUpHashChanged', function (e) {
-                    processHash(e.detail);
+                    processHash(e, e.detail);
                 });
 
                 updateDataFromCache(_adal.config.loginResource);


### PR DESCRIPTION
Function `processHash` has the following two lines:

```
// since this is a token renewal request in iFrame, we don't need to proceed with the location change.
event.preventDefault();
```

This causes an error, because there is no variable `event`. We need to pass it in to the function in order for the code to work.

When does this happen? When we make an API request to a 3rd party service (this triggers Adal.js to first get a token via an Iframe).

This PR resolves the following issues:

1. https://github.com/AzureAD/azure-activedirectory-library-for-js/issues/500 **event is undefined in processHash function**
2. https://github.com/AzureAD/azure-activedirectory-library-for-js/issues/518 **ADAL 1.0.14 issue in Firefox 51.0.1 "event is not defined"**