### PR TITLE
Don't enforce user info in acquireToken()

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -519,12 +519,6 @@ var AuthenticationContext = (function () {
             return;
         }
 
-        if (!this._user) {
-            this.warn('User login is required');
-            callback('User login is required', null, 'login required');
-            return;
-        }
-
         // refresh attept with iframe
         //Already renewing for this resource, callback when we get the token.
         if (this._activeRenewals[resource]) {


### PR DESCRIPTION
user info/idToken isn't necessary to obtain access tokens in implicit grant flow, adal should allow acquiring tokens purely based on the existence of AAD session cookie.