### PR TITLE
Use url generated from target state for adal.login.request

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -179,7 +179,7 @@
 
                 };
 
-                var loginHandler = function () {
+                var loginHandler = function (returnUrl) {
                     _adal.info('Login event for:' + $location.$$url);
                     if (_adal.config && _adal.config.localLoginUrl) {
                         $location.path(_adal.config.localLoginUrl);
@@ -188,7 +188,7 @@
                         // directly start login flow
                         _adal.info('Start login at:' + $location.$$absUrl);
                         $rootScope.$broadcast('adal:loginRedirect');
-                        _adal.login($location.$$absUrl);
+                        _adal.login(returnUrl || $location.$$absUrl);
                     }
                 };
 
@@ -264,7 +264,8 @@
                                 if (!_oauthData.isAuthenticated) {
                                     if (!_adal._renewActive && !_adal.loginInProgress()) {
                                         _adal.info('State change event for:' + $location.$$url);
-                                        loginHandler();
+                                        var $state = $injector.get('$state');
+                                        loginHandler(window.location.origin + '/' + $state.href(toState, toParams));
                                     }
                                 }
                             }


### PR DESCRIPTION
This is a suggested fix for #536. The main issue is that `$location` is used for determining the return URL after login. However, the `$stateChangeStart` event doesn't update the `$location` url, so the user is returned back to the original state instead of the protected one they were trying to get to.

This change generates the target URL from the state inside of the `$stateChangeStart` event, and modifies the login handler to accept the generated `returnUrl` as an an optional parameter.