### PR TITLE
Prevent login_hint from being added twice when acquiring token (#517)

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -672,8 +672,11 @@ var AuthenticationContext = (function () {
         // include hint params only if upn is present
         if (this._user && this._user.profile && this._user.profile.hasOwnProperty('upn')) {
 
-            // add login_hint
-            urlNavigate += '&login_hint=' + encodeURIComponent(this._user.profile.upn);
+            // don't add login_hint twice if user provided it in the extraQueryParameter value
+            if (!this._urlContainsQueryStringParameter("login_hint", urlNavigate)) {
+                // add login_hint
+                urlNavigate += '&login_hint=' + encodeURIComponent(this._user.profile.upn);
+            }
 
             // don't add domain_hint twice if user provided it in the extraQueryParameter value
             if (!this._urlContainsQueryStringParameter("domain_hint", urlNavigate) && this._user.profile.upn.indexOf('@') > -1) {


### PR DESCRIPTION
Not sure if you had a different solution in mind to solve this, but similar to `domain_hint`, this checks if it's in the url already and only adds it if it isn't.