### PR TITLE
Fix hash handling of angular

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -69,12 +69,11 @@
 
                 var locationChangeHandler = function (event, newUrl, oldUrl) {
                     _adal.verbose('Location change event from ' + oldUrl + ' to ' + newUrl);
-                    if ($location.$$html5) {
-                        var hash = $location.hash();
-                    }
-                    else {
-                        var hash = '#' + $location.path();
-                    }
+ 
+                    var hash = $location.hash();
+                    
+                    _adal.verbose('Hash: ' + hash);
+                    
                     processHash(hash, event);
 
                     $timeout(function () {


### PR DESCRIPTION
Using Angular 1.6.4, path does not return the hash part, but hash does. Works fine also if route handler is in use.
eg. #!/bla#state=34545