### PR TITLE
Token Renewal Failed

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -350,8 +350,8 @@ var AuthenticationContext = (function () {
         if (expiry && (expiry > this._now() + offset)) {
             return token;
         } else {
-            this._saveItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + resource, '');
-            this._saveItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + resource, 0);
+            this.removeCachedKeys();
+            
             return null;
         }
     };
@@ -686,6 +686,39 @@ var AuthenticationContext = (function () {
             }
         }
         this._saveItem(this.CONSTANTS.STORAGE.TOKEN_KEYS, '');
+    };
+    
+     /**
+     * Remove cached keys.
+     */
+    AuthenticationContext.prototype.removeCachedKeys = function ()
+    {
+        window.renewStates = [];
+
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.SESSION_STATE);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.STATE_LOGIN);
+        
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.USERNAME);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.IDTOKEN);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.ERROR);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.ERROR_DESCRIPTION);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.NONCE_IDTOKEN);
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.RENEW_STATUS + this.config.clientId);
+
+        var keys = this._getItem(this.CONSTANTS.STORAGE.TOKEN_KEYS);
+
+        if (!this._isEmpty(keys))
+        {
+            keys = keys.split(this.CONSTANTS.RESOURCE_DELIMETER);
+            for (var i = 0; i < keys.length; i++)
+            {
+                sessionStorage.removeItem(this.CONSTANTS.STORAGE.ACCESS_TOKEN_KEY + keys[i]);
+                sessionStorage.removeItem(this.CONSTANTS.STORAGE.EXPIRATION_KEY + keys[i]);
+            }
+        }
+        sessionStorage.removeItem(this.CONSTANTS.STORAGE.TOKEN_KEYS);
     };
 
     /**


### PR DESCRIPTION
Fixing issue #578

I was able to reproduce the issue #578 using just adal.js in a React SPA. To solve, I've removed from the sessionStorage the keys related to the adal. After that, it's working.