### PR TITLE
Hide iframe contents from screen reader

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1451,6 +1451,7 @@ var AuthenticationContext = (function () {
                 (window.opera || window.navigator.userAgent.indexOf('MSIE 5.0') === -1)) {
                 var ifr = document.createElement('iframe');
                 ifr.setAttribute('id', iframeId);
+                ifr.setAttribute('aria-hidden', 'true');
                 ifr.style.visibility = 'hidden';
                 ifr.style.position = 'absolute';
                 ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';


### PR DESCRIPTION
Ran into a case at least with VoiceOver on iOS and Mac, where the iframe contents for adal were being read and getting focus by screen reader.  It may also affect other browser + screen reader combinations. This interrupts focus order/navigation for these users and is an unpleasant experience in general.