### PR TITLE
Make postLogoutRedirectUri optional

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -160,7 +160,7 @@ var AuthenticationContext = (function () {
             this.config.redirectUri = window.location.href.split("?")[0].split("#")[0];
         }
 
-        if (!this.config.postLogoutRedirectUri) {
+        if (this.config.postLogoutRedirectUri === undefined) {
             // strip off query parameters or hashes from the post logout redirect uri as AAD does not allow those.
             this.config.postLogoutRedirectUri = window.location.href.split("?")[0].split("#")[0];
         }
@@ -746,10 +746,10 @@ var AuthenticationContext = (function () {
             }
 
             if (this.config.postLogoutRedirectUri) {
-                logout = 'post_logout_redirect_uri=' + encodeURIComponent(this.config.postLogoutRedirectUri);
+                logout = '?post_logout_redirect_uri=' + encodeURIComponent(this.config.postLogoutRedirectUri);
             }
 
-            urlNavigate = this.instance + tenant + '/oauth2/logout?' + logout;
+            urlNavigate = this.instance + tenant + '/oauth2/logout' + logout;
         }
 
         this.info('Logout navigate to: ' + urlNavigate);


### PR DESCRIPTION
Only set the postLogoutRedirectUri if the value in the config is undefined. Other falsey values will leave the `post_logout_redirect_uri` query parameter off of the logout url