### PR TITLE
validate window object exists before using it

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -121,9 +121,11 @@ var AuthenticationContext = (function () {
         this._loginInProgress = false;
         this._acquireTokenInProgress = false;
 
-        window.renewStates = [];
-        window.callBackMappedToRenewStates = {};
-        window.callBacksMappedToRenewStates = {};
+        if(typeof window !== 'undefined') {
+            window.renewStates = [];
+            window.callBackMappedToRenewStates = {};
+            window.callBacksMappedToRenewStates = {};
+        }
 
         // validate before constructor assignments
         if (config.displayCall && typeof config.displayCall !== 'function') {
@@ -154,13 +156,13 @@ var AuthenticationContext = (function () {
             this.config.loginResource = this.config.clientId;
         }
 
-        // redirect and logout_redirect are set to current location by default
-        if (!this.config.redirectUri) {
+        // redirect and logout_redirect are set to current location by default if available
+        if (!this.config.redirectUri && typeof window !== 'undefined') {
             // strip off query parameters or hashes from the redirect uri as AAD does not allow those.
             this.config.redirectUri = window.location.href.split("?")[0].split("#")[0];
         }
 
-        if (!this.config.postLogoutRedirectUri) {
+        if (!this.config.postLogoutRedirectUri && typeof window !== 'undefined') {
             // strip off query parameters or hashes from the post logout redirect uri as AAD does not allow those.
             this.config.postLogoutRedirectUri = window.location.href.split("?")[0].split("#")[0];
         }


### PR DESCRIPTION
When testing on a headless browser (PhantomJS), the window object may
not be available at the time the AuthenticationContext is instantiated,
resulting in ReferenceError. Skipping these steps when window is not
available allows for testing on headless browsers but may result in 
unpredictable behavior in situations that previously would have 
resulted in ReferenceError.

See also 
https://github.com/AzureAD/azure-activedirectory-library-for-js/
commit/c096ad247e918cf00c9bcfd729ce24a075b8cd00