### PR TITLE
Update prompt param if it's already provided in the url (fix fo #636)

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -434,8 +434,8 @@ var AuthenticationContext = (function () {
         // renew happens in iframe, so it keeps javascript context
         window.renewStates.push(expectedState);
 
-        this.verbose('Renew token Expected state: ' + expectedState);
-        var urlNavigate = this._getNavigateUrl('token', resource) + '&prompt=none';
+        this.verbose('Renew token Expected state: ' + expectedState);        
+        var urlNavigate = this._addOrUpdateUrlQueryStringParameter('prompt', 'none', this._getNavigateUrl('token', resource));
         urlNavigate = this._addHintParameters(urlNavigate);
 
         this.registerCallback(expectedState, resource, callback);
@@ -460,8 +460,8 @@ var AuthenticationContext = (function () {
         // renew happens in iframe, so it keeps javascript context
         window.renewStates.push(expectedState);
 
-        this.verbose('Renew Idtoken Expected state: ' + expectedState);
-        var urlNavigate = this._getNavigateUrl('id_token', null) + '&prompt=none';
+        this.verbose('Renew Idtoken Expected state: ' + expectedState);        
+        var urlNavigate = this._addOrUpdateUrlQueryStringParameter('prompt', 'none', this._getNavigateUrl('token', null));
         urlNavigate = this._addHintParameters(urlNavigate);
 
         urlNavigate += '&nonce=' + encodeURIComponent(this._idTokenNonce);
@@ -480,6 +480,23 @@ var AuthenticationContext = (function () {
         // regex to detect pattern of a ? or & followed by the name parameter and an equals character
         var regex = new RegExp("[\\?&]" + name + "=");
         return regex.test(url);
+    }
+
+    /**
+     * Adds query parameter to url or update it with the new value
+     * @ignore
+     */
+    AuthenticationContext.prototype._addOrUpdateUrlQueryStringParameter = function (name, value, url) {
+        // add parameter if it's 
+        if (!this._urlContainsQueryStringParameter(name, url)) {                
+                url += '&' + name + '=' + value;
+        } else {
+            // replace the existing value with the new one
+            var regex = new RegExp('(' + name + '=)[^\&]+');  
+            url = url.replace( regex , '$1' + value);
+        }
+
+        return url;
     }
 
     // Calling _loadFrame but with a timeout to signal failure in loadframeStatus. Callbacks are left
@@ -604,11 +621,12 @@ var AuthenticationContext = (function () {
         var expectedState = this._guid() + '|' + resource;
         this.config.state = expectedState;
         window.renewStates.push(expectedState);
-        this.verbose('Renew token Expected state: ' + expectedState);
-        var urlNavigate = this._getNavigateUrl('token', resource) + '&prompt=select_account';
+        this.verbose('Renew token Expected state: ' + expectedState);        
+        var urlNavigate = this._getNavigateUrl('token', resource);        
         if (extraQueryParameters) {
             urlNavigate += encodeURIComponent(extraQueryParameters);
         }
+        urlNavigate = this._addOrUpdateUrlQueryStringParameter('prompt', 'select_account', urlNavigate);
 
         if (claims && (urlNavigate.indexOf("&claims") === -1)) {
             urlNavigate += '&claims=' + encodeURIComponent(claims);
@@ -653,11 +671,13 @@ var AuthenticationContext = (function () {
         var expectedState = this._guid() + '|' + resource;
         this.config.state = expectedState;
         window.renewStates.push(expectedState);
-        this.verbose('Renew token Expected state: ' + expectedState);
-        var urlNavigate = this._getNavigateUrl('token', resource) + '&prompt=select_account';
+        this.verbose('Renew token Expected state: ' + expectedState);        
+        var urlNavigate = this._getNavigateUrl('token', resource);        
         if (extraQueryParameters) {
             urlNavigate += encodeURIComponent(extraQueryParameters);
         }
+
+        urlNavigate = this._addOrUpdateUrlQueryStringParameter('prompt', 'select_account', urlNavigate);
 
         if (claims && (urlNavigate.indexOf("&claims") === -1)) {
             urlNavigate += '&claims=' + encodeURIComponent(claims);
@@ -819,7 +839,7 @@ var AuthenticationContext = (function () {
         }
 
         return urlNavigate;
-    }
+    }    
 
     /**
      * Creates a user object by decoding the id_token

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -461,7 +461,7 @@ var AuthenticationContext = (function () {
         window.renewStates.push(expectedState);
 
         this.verbose('Renew Idtoken Expected state: ' + expectedState);        
-        var urlNavigate = this._addOrUpdateUrlQueryStringParameter('prompt', 'none', this._getNavigateUrl('token', null));
+        var urlNavigate = this._addOrUpdateUrlQueryStringParameter('prompt', 'none', this._getNavigateUrl('id_token', null));
         urlNavigate = this._addHintParameters(urlNavigate);
 
         urlNavigate += '&nonce=' + encodeURIComponent(this._idTokenNonce);


### PR DESCRIPTION
Extracted the function to add parameter to the url. It should prevent duplicated params to appear.