### PR TITLE
Replaced usage of lambda functions for IE11 support.

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -329,11 +329,11 @@
                     var $transitions = $injector.get('$transitions');
 
                     function onStartStateChangeHandler(transition) {
-                        stateChangeHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'))
+                        stateChangeHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'));
                     }
 
                     function onErrorStateChangeHandler(transition) {
-                        stateChangeErrorHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'), transition.error())
+                        stateChangeErrorHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'), transition.error());
                     }
 
                     $transitions.onStart({}, onStartStateChangeHandler);

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -327,8 +327,17 @@
 
                 if ($injector.has('$transitions')) {
                     var $transitions = $injector.get('$transitions');
-                    $transitions.onStart({}, (transition) => stateChangeHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from')));
-                    $transitions.onError({}, (transition) => stateChangeErrorHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'), transition.error()));
+
+                    function onStartStateChangeHandler(transition) {
+                        stateChangeHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'))
+                    }
+
+                    function onErrorStateChangeHandler(transition) {
+                        stateChangeErrorHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'), transition.error())
+                    }
+
+                    $transitions.onStart({}, onStartStateChangeHandler);
+                    $transitions.onError({}, onErrorStateChangeHandler);
                 }
 
                 // Route change event tracking to receive fragment and also auto renew tokens


### PR DESCRIPTION
Lambda functions aren't currently supported by IE. I've replaced the usage of lambda's with equivalent functions created in the scope of usage to make this library IE compatible again.

For more about lambda function compatibility see [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Browser_compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Browser_compatibility)