### PR TITLE
fix: forwarding request without token to endpoint

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -517,8 +517,7 @@
                                     config.headers.Authorization = 'Bearer ' + token;
                                     delayedRequest.resolve(config);
                                 }, function (error) {
-                                    config.data = error;
-                                    delayedRequest.reject(config);
+                                    delayedRequest.resolve(config);
                                 });
 
                                 return delayedRequest.promise;


### PR DESCRIPTION
There are situations when an application wants to work with endpoint which offer some actions
which require authentication/authorization and some actions which don't.
It's good to forward requests to this type of endpoint because
actions will decide to accept request or not. Without this change (in this pull request), user
must be logged in if he/she wants to send request to an action which doesn't require authentication/authorization of endpoint which is added in initialization of adalAuthenticationServiceProvider.