### PR TITLE
Cache the values of _supportsLocalStorage and _supportsSessionStorage

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -135,6 +135,10 @@ var AuthenticationContext = (function () {
         this._openedWindows = [];
         this._requestType = this.REQUEST_TYPE.LOGIN;
         window._adalInstance = this;
+        this._storageSupport = {
+            localStorage: null,
+            sessionStorage: null
+        };
 
         // validate before constructor assignments
         if (config.displayCall && typeof config.displayCall !== 'function') {
@@ -924,7 +928,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don’t use prompt=none, then if the session does not exist, there will be a failure.
+        //If you donï¿½t use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 
@@ -1759,20 +1763,44 @@ var AuthenticationContext = (function () {
     };
 
     /**
+     * Returns true if the browser supports given storage type
+     * @ignore
+     */
+    AuthenticationContext.prototype._supportsStorage = function(storageType) {
+        if (!(storageType in this._storageSupport)) {
+            return false;
+        }
+
+        if (this._storageSupport[storageType] !== null) {
+            return this._storageSupport[storageType];
+        }
+
+        try {
+            if (!(storageType in window) || window[storageType] === null) {
+                throw new Error();
+            }
+            var testKey = '__storageTest__';
+            window[storageType].setItem(testKey, 'A');
+            if (window[storageType].getItem(testKey) !== 'A') {
+                throw new Error();
+            }
+            window[storageType].removeItem(testKey);
+            if (window[storageType].getItem(testKey)) {
+                throw new Error();
+            }
+            this._storageSupport[storageType] = true;
+        } catch (e) {
+            this._storageSupport[storageType] = false;
+        }
+        return this._storageSupport[storageType];
+    }
+
+    /**
      * Returns true if browser supports localStorage, false otherwise.
      * @ignore
      */
-    AuthenticationContext.prototype._supportsLocalStorage = function () {
-        try {
-            if (!window.localStorage) return false; // Test availability
-            window.localStorage.setItem('storageTest', 'A'); // Try write
-            if (window.localStorage.getItem('storageTest') != 'A') return false; // Test read/write
-            window.localStorage.removeItem('storageTest'); // Try delete
-            if (window.localStorage.getItem('storageTest')) return false; // Test delete
-            return true; // Success
-        } catch (e) {
-            return false;
-        }
+    AuthenticationContext.prototype._supportsLocalStorage = function () {        
+        return this._supportsStorage('localStorage');
     };
 
     /**
@@ -1780,16 +1808,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._supportsSessionStorage = function () {
-        try {
-            if (!window.sessionStorage) return false; // Test availability
-            window.sessionStorage.setItem('storageTest', 'A'); // Try write
-            if (window.sessionStorage.getItem('storageTest') != 'A') return false; // Test read/write
-            window.sessionStorage.removeItem('storageTest'); // Try delete
-            if (window.sessionStorage.getItem('storageTest')) return false; // Test delete
-            return true; // Success
-        } catch (e) {
-            return false;
-        }
+        return this._supportsStorage('sessionStorage');
     };
 
     /**

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -1098,4 +1098,20 @@ describe('Adal', function () {
         expect(Logging.level).toEqual(2);
         Logging.piiLoggingEnabled = false;
     })
+
+    it('checks if localStorage is available', function () {
+        expect(adal._supportsLocalStorage()).toBe(true);
+    })
+
+    it('reports localStorage unavailable if window.localStorage is null', function () {
+        window.localStorage = null;
+        expect(adal._supportsLocalStorage()).toBe(false);
+    })
+
+    it('reports localStorage unavailable if window.localStorage fails to save', function () {
+        window.localStorage.setItem = function(key, value) {
+            return;
+        }
+        expect(adal._supportsLocalStorage()).toBe(false);
+    })
 });


### PR DESCRIPTION
Cache the values of `AuthenticationContext.prototype._supportsLocalStorage` and `AuthenticationContext.prototype._supportsSessionStorage` to avoid performance pressure on the browser's local storage APIs.