### PR TITLE
Fix setting of the borderWidth on adal frame

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -924,7 +924,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don’t use prompt=none, then if the session does not exist, there will be a failure.
+        //If you don't use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 
@@ -1684,7 +1684,7 @@ var AuthenticationContext = (function () {
                 ifr.setAttribute('aria-hidden', 'true');
                 ifr.style.visibility = 'hidden';
                 ifr.style.position = 'absolute';
-                ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';
+                ifr.style.width = ifr.style.height = ifr.style.borderWidth = '0px';
 
                 adalFrame = document.getElementsByTagName('body')[0].appendChild(ifr);
             }


### PR DESCRIPTION
This fixes #788, #682, & #562. The root cause was the the code was not correctly setting the borderWidth since it didn't use the style object. Because of this it failed to override default user agent styles provided by the browser causing the iframe to require space.

I also updated a `'` character that was not using the proper encoding in a comment.