### PR TITLE
Reworking callback context

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -924,7 +924,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don’t use prompt=none, then if the session does not exist, there will be a failure.
+        //If you donï¿½t use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 
@@ -1317,7 +1317,7 @@ var AuthenticationContext = (function () {
                 self = this._openedWindows[this._openedWindows.length - 1].opener._adalInstance;
                 isPopup = true;
             }
-            else if (window.parent && window.parent._adalInstance) {
+            else if (window._adalInstance) {
                 self = window.parent._adalInstance;
             }
 
@@ -1359,9 +1359,11 @@ var AuthenticationContext = (function () {
                 self.error("Error occurred in user defined callback function: " + err);
             }
 
-            if (window.parent === window && !isPopup) {
+            if (!isPopup) {
                 if (self.config.navigateToLoginRequestUrl) {
-                    window.location.href = self._getItem(self.CONSTANTS.STORAGE.LOGIN_REQUEST);
+                    if (window.location.href !== self._getItem(self.CONSTANTS.STORAGE.LOGIN_REQUEST)) {
+                        window.location.href = self._getItem(self.CONSTANTS.STORAGE.LOGIN_REQUEST);
+                    }  
                 } else window.location.hash = '';
             }
         }

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1678,10 +1678,17 @@ var AuthenticationContext = (function () {
         this.info('Add adal frame to document:' + iframeId);
         var adalFrame = document.getElementById(iframeId);
 
+        var handleFrameCallback = function() {
+            if(adalFrame) {
+                that.handleWindowCallback(adalFrame.contentWindow.location.hash);
+            }
+        }
+
         if (!adalFrame) {
             if (document.createElement && document.documentElement &&
                 (window.opera || window.navigator.userAgent.indexOf('MSIE 5.0') === -1)) {
                 var ifr = document.createElement('iframe');
+                ifr.onload = handleFrameCallback;
                 ifr.setAttribute('id', iframeId);
                 ifr.setAttribute('aria-hidden', 'true');
                 ifr.style.visibility = 'hidden';


### PR DESCRIPTION
The work in this pull request originates from internship project at Microsoft in which we used adal.js for a VSTS Extension. There were issues where context assumptions (primarily that `window.parent === window`) would prevent adal from properly handling window callbacks. Once those assumptions were rearranged, things began to work. Hoping that maintainers can see the changes I made and provide feedback on the substance of them, and if they are aware of other portions within handleWindowCallback() that they can be addressed.