### PR TITLE
fixed circular reference error in JSON.stringify

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -315,7 +315,7 @@
                 };
 
                 var stateChangeErrorHandler = function (event, toState, toParams, fromState, fromParams, error) {
-                    _adal.verbose("State change error occured. Error: " + typeof (error) === 'string' ? error : JSON.stringify(error));
+                    _adal.verbose("State change error occured. Error: " + typeof (error) === 'string' ? error : JSON.stringify(error, jsonCircularReferenceReplacer()));
                     // adal interceptor sets the error on config.data property. If it is set, it means state change is rejected by adal,
                     // in which case set the defaultPrevented to true to avoid url update as that sometimesleads to infinte loop.
                     if (error && error.data) {
@@ -324,6 +324,19 @@
                             event.preventDefault();
                     }
                 };
+
+                var jsonCircularReferenceReplacer = function () {
+                    var cache = [];
+                    return function (key, value) {
+                        if (typeof value === "object" && value !== null) {
+                            if (cache.indexOf(value) !== -1) {
+                                return;
+                            }
+                            cache.push(value);
+                        }
+                        return value;
+                    };
+                }
 
                 if ($injector.has('$transitions')) {
                     var $transitions = $injector.get('$transitions');
@@ -527,7 +540,7 @@
                     }
                 },
                 responseError: function (rejection) {
-                    authService.info('Getting error in the response: ' + JSON.stringify(rejection));
+                    authService.info('Getting error in the response: ' + JSON.stringify(rejection, jsonCircularReferenceReplacer()));
                     if (rejection) {
                         if (rejection.status === 401) {
                             var resource = authService.getResourceForEndpoint(rejection.config.url);


### PR DESCRIPTION
*Fixed bug with JSON.stringify(object) when object has circular reference.
Issue https://github.com/AzureAD/azure-activedirectory-library-for-js/issues/806
