### PR TITLE
fix: strict mode nested function adal-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can learn in detail about ADAL JS installation and usage documented in the [
 
 ## Versions
 
-Current version - **1.0.17**  
+Current version - **1.0.18**  
 Minimum recommended version - 1.0.11  
 You can find the changes for each version in the [change log](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/master/changelog.txt).
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.0.18
+=========================
+* Bugfix for angular-adal when using strict mode. This takes out functions within a nested conditional block.
+
 Version 1.0.17
 =========================
 * Added sid support. When the session id parameter is provided in the id_token, use that instead of the upn

--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -341,16 +341,13 @@
                 if ($injector.has('$transitions')) {
                     var $transitions = $injector.get('$transitions');
 
-                    function onStartStateChangeHandler(transition) {
+                    $transitions.onStart({}, function onStartStateChangeHandler(transition) {
                         stateChangeHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'));
-                    }
-
-                    function onErrorStateChangeHandler(transition) {
+                    });
+                    
+                    $transitions.onError({}, function onErrorStateChangeHandler(transition) {
                         stateChangeErrorHandler(null, transition.to(), transition.params('to'), transition.from(), transition.params('from'), transition.error());
-                    }
-
-                    $transitions.onStart({}, onStartStateChangeHandler);
-                    $transitions.onError({}, onErrorStateChangeHandler);
+                    });
                 }
 
                 // Route change event tracking to receive fragment and also auto renew tokens

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/AzureAD/azure-activedirectory-library-for-js.git"
   },
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Windows Azure Active Directory Client Library for js",
   "keywords": [
     "implicit",


### PR DESCRIPTION
When using the adal-angular library within PhantomJS and strict mode (and in my case Chisel Web Accessibility tool), it throws an error keeping the AngularJS app from running. Moving in the function declaration to an inline call fixes this.

### Tests
Unfortunately, there is no way to test this from what I can tell. If you think you can, please let me know and I'll update.