### PR TITLE
Reverse the #839 Circular Reference Error Fix - currently customer reported a scope error

### DIFF
--- a/lib/adal-angular.js
+++ b/lib/adal-angular.js
@@ -315,7 +315,7 @@
                 };
 
                 var stateChangeErrorHandler = function (event, toState, toParams, fromState, fromParams, error) {
-                    _adal.verbose("State change error occured. Error: " + typeof (error) === 'string' ? error : JSON.stringify(error, jsonCircularReferenceReplacer()));
+                    _adal.verbose("State change error occured. Error: " + typeof (error) === 'string' ? error : JSON.stringify(error));
                     // adal interceptor sets the error on config.data property. If it is set, it means state change is rejected by adal,
                     // in which case set the defaultPrevented to true to avoid url update as that sometimesleads to infinte loop.
                     if (error && error.data) {
@@ -324,19 +324,6 @@
                             event.preventDefault();
                     }
                 };
-
-                var jsonCircularReferenceReplacer = function () {
-                    var cache = [];
-                    return function (key, value) {
-                        if (typeof value === "object" && value !== null) {
-                            if (cache.indexOf(value) !== -1) {
-                                return;
-                            }
-                            cache.push(value);
-                        }
-                        return value;
-                    };
-                }
 
                 if ($injector.has('$transitions')) {
                     var $transitions = $injector.get('$transitions');
@@ -540,7 +527,7 @@
                     }
                 },
                 responseError: function (rejection) {
-                    authService.info('Getting error in the response: ' + JSON.stringify(rejection, jsonCircularReferenceReplacer()));
+                    authService.info('Getting error in the response: ' + JSON.stringify(rejection));
                     if (rejection) {
                         if (rejection.status === 401) {
                             var resource = authService.getResourceForEndpoint(rejection.config.url);


### PR DESCRIPTION
Reverting the change for further inspection as a user reported "jsonCircularReferenceReplacer() is undefined in the responseError of AdalModule.factory due to the scope it is placed at here."