### PR TITLE
Call getCachedUser in acquireToken to avoid bugs related to renew 

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -926,7 +926,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don�t use prompt=none, then if the session does not exist, there will be a failure.
+        //If you dont use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -649,7 +649,9 @@ var AuthenticationContext = (function () {
             return;
         }
 
-        if (!this._user && !(this.config.extraQueryParameter && this.config.extraQueryParameter.indexOf('login_hint') !== -1)) {
+        //get user from cache, since this will be null if page is reloaded
+        var user = this.getCachedUser();
+        if (!user && !(this.config.extraQueryParameter && this.config.extraQueryParameter.indexOf('login_hint') !== -1)) {
             this.warn('User login is required');
             callback('User login is required', null, 'login required');
             return;
@@ -666,7 +668,7 @@ var AuthenticationContext = (function () {
             if (resource === this.config.clientId) {
                 // App uses idtoken to send to api endpoints
                 // Default resource is tracked as clientid to store this token
-                if (this._user) {
+                if (user) {
                     this.verbose('renewing idtoken');
                     this._renewIdToken(callback);
                 }
@@ -675,7 +677,7 @@ var AuthenticationContext = (function () {
                     this._renewIdToken(callback, this.RESPONSE_TYPE.ID_TOKEN_TOKEN);
                 }
             } else {
-                if (this._user) {
+                if (user) {
                     this.verbose('renewing access_token');
                     this._renewToken(resource, callback);
                 }
@@ -924,7 +926,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don’t use prompt=none, then if the session does not exist, there will be a failure.
+        //If you donï¿½t use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 


### PR DESCRIPTION
Directly calling this._user in acquireToken will result in a "User login is required" error if the page has been reloaded. 

The fix is to call getCachedUser, so that user is loaded from cache.

This solves #764

PR against master as this is a pressing issue that should be fixed asap. Please advice if I should use another branch.