### PR TITLE
Fix #862, use CDN links for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Via NPM (https://www.npmjs.com/package/adal-angular):
 Via CDN:
 
     <!-- Latest compiled and minified JavaScript -->
-    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.18/js/adal.min.js"></script>
-    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.18/js/adal-angular.min.js"></script>
+    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.17/js/adal.min.js"></script>
+    <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.17/js/adal-angular.min.js"></script>
 
 Via Bower:
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can learn further details about ADAL.js functionality documented in the [ADA
 
 ## Versions
 
-Current version - **1.0.18**  
+Current version - **1.0.17**  
 Minimum recommended version - 1.0.11  
 You can find the changes for each version in the [change log](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #862 . This updates the library's CDN links and references to version 1.0.18 so that they use the latest available release (at the time of committing).
These links were changed in 0239b400a2048aa8a8763fa18e068a69219441f6, which appears to have been copied/cherry-picked from the dev branch where 1.0.18 is being worked on (PR #839 ). 

Since this release is not out yet, and these links 404, they have been updated to use the latest release of the library (1.0.17).