### PR TITLE
Fixing incorrectly placed delimiter

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -924,7 +924,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don’t use prompt=none, then if the session does not exist, there will be a failure.
+        //If you donï¿½t use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 
@@ -1715,7 +1715,7 @@ var AuthenticationContext = (function () {
 
             if (preserve) {
                 var value = this._getItem(key) || '';
-                localStorage.setItem(key, value + obj + this.CONSTANTS.CACHE_DELIMETER);
+                localStorage.setItem(key, this._isEmpty(value) ? obj : (value + this.CONSTANTS.CACHE_DELIMETER + obj));
             }
             else {
                 localStorage.setItem(key, obj);


### PR DESCRIPTION
Problem:
- Adal 1.0.17 supports saving items with delimiter in Local Storage
e.g: adal.nonce.idtoken	585bf368-cbb1-4619-8e40-3feeff59ecbd||9832338-cbb1-4619-8e40-3feeff59ecbd 
- Teams Web client uses ADAL 1.0.9 where items are stored without delimiter 
e.g: adal.nonce.idtoken	585bf368-cbb1-4619-8e40-3feeff59ecbd
- Teams N* experience uses 1.0.17. But in case user has Teams web client open in different tab, same local storage will be used. 
- 1.0.17 does not check whether local storage contains value and appends new value to old value and then delimiter
adal.nonce.idtoken	585bf368-cbb1-4619-8e40-3feeff59ecbd9832338-cbb1-4619-8e40-3feeff59ecbd**||**
- During login, matchNonce function will fail as value will be incorrect on split by delimiter, and user will not be created. This fails Teams N* scenarios. 
- Hence fix is to save old value + delimiter + new value for ADAL 1.0.17 and 1.0.9 teams clients to work together

Testing:
- Can be verified with two sample apps, one with 1.0.17 and another with 1.0.9 and reusing adal.nonce.idtoken from Local storage cache.