### PR TITLE
Make sure _loadFrameTimeout clean up _activeRenewals when facing timeout

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -596,6 +596,7 @@ var AuthenticationContext = (function () {
                     self._callBackMappedToRenewStates[expectedState]('Token renewal operation failed due to timeout', null, 'Token Renewal Failed');
                 }
 
+                self._activeRenewals[resource] = null;
                 self._saveItem(self.CONSTANTS.STORAGE.RENEW_STATUS + resource, self.CONSTANTS.TOKEN_RENEW_STATUS_CANCELED);
             }
         }, self.CONSTANTS.LOADFRAME_TIMEOUT);
@@ -924,7 +925,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._addHintParameters = function (urlNavigate) {
-        //If you don’t use prompt=none, then if the session does not exist, there will be a failure.
+        //If you don't use prompt=none, then if the session does not exist, there will be a failure.
         //If sid is sent alongside domain or login hints, there will be a failure since request is ambiguous.
         //If sid is sent with a prompt value other than none or attempt_none, there will be a failure since the request is ambiguous.
 


### PR DESCRIPTION
Why:
We notice a bug with ADAL that sometimes, after browsers being sleep/idle for a while, ADAL gets into a weird state that "adal.token.renew.status" is "canceled", but new acquireToken calls are only registered in callbacks and not triggered.

How:
We update the _loadFrameTimeout function to make sure it will clean up the _activeRenewals for a given resource when timeout happens.