### PR TITLE
Fix border-width style on hidden adal frame

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1685,7 +1685,7 @@ var AuthenticationContext = (function () {
                 ifr.setAttribute('aria-hidden', 'true');
                 ifr.style.visibility = 'hidden';
                 ifr.style.position = 'absolute';
-                ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';
+                ifr.style.width = ifr.style.height = ifr.style.borderWidth = '0px';
 
                 adalFrame = document.getElementsByTagName('body')[0].appendChild(ifr);
             }


### PR DESCRIPTION
When `borderWidth` isn't set properly, the browser applies a default
non-zero width which then interferes with the page layout. The frame
wasn't truly 'hidden'.