### PR TITLE
Reduce the likelihood of ADAL being stuck

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -591,13 +591,12 @@ var AuthenticationContext = (function () {
                 // fail the iframe session if it's in pending state
                 self.verbose('Loading frame has timed out after: ' + (self.CONSTANTS.LOADFRAME_TIMEOUT / 1000) + ' seconds for resource ' + resource);
                 var expectedState = self._activeRenewals[resource];
+                self._activeRenewals[resource] = null;
+                self._saveItem(self.CONSTANTS.STORAGE.RENEW_STATUS + resource, self.CONSTANTS.TOKEN_RENEW_STATUS_CANCELED);
 
                 if (expectedState && self._callBackMappedToRenewStates[expectedState]) {
                     self._callBackMappedToRenewStates[expectedState]('Token renewal operation failed due to timeout', null, 'Token Renewal Failed');
                 }
-
-                self._activeRenewals[resource] = null;
-                self._saveItem(self.CONSTANTS.STORAGE.RENEW_STATUS + resource, self.CONSTANTS.TOKEN_RENEW_STATUS_CANCELED);
             }
         }, self.CONSTANTS.LOADFRAME_TIMEOUT);
     }


### PR DESCRIPTION
Why:
After our previous change (https://github.com/AzureAD/azure-activedirectory-library-for-js/commit/6a09d3731f4edc7f20169995e169f8baeefc6c58), we see less ADAL stuck errors. However, this ADAl stuck error still happens from time to time. And this PR is to further reduce the likelihood of this error.

How:
Move the code cleanning up "self._activeRenewals[resource]" before we trigger callbacks when loading frame times out, so we guarantee that "self._activeRenewals[resource]" will be cleaned up for sure, and won't be interrupted by issues happening during triggering callbacks.