### PR TITLE
[Yammer] improve logout experience in multiple tabs of the same application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 
-This library, ADAL for JavaScript, will no longer receive new feature improvements. Instead, use the new
+This library, ADAL for JavaScript, will no longer receive new feature improvements. Instead, use the new library
 [MSAL.js](https://github.com/AzureAD/microsoft-authentication-library-for-js).
 
 * If you are starting a new project, you can get started with the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library, ADAL for JavaScript, will no longer receive new feature improvemen
   [MSAL.js docs](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki)
   for details about the scenarios, usage, and relevant concepts.
 * If your application is using the previous ADAL JavaScript library, you can follow this
-  [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-compare-msal-js-and-adal-js)
+  [migration guide](https://docs.microsoft.com/azure/active-directory/develop/msal-compare-msal-js-and-adal-js)
   to update to MSAL.js.
 * Existing applications relying on ADAL JavaScript will continue to work.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+---
+
+This library, ADAL for JavaScript, will no longer receive new feature improvements. Instead, use the new
+[MSAL.js](https://github.com/AzureAD/microsoft-authentication-library-for-js).
+
+* If you are starting a new project, you can get started with the
+  [MSAL.js docs](https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki)
+  for details about the scenarios, usage, and relevant concepts.
+* If your application is using the previous ADAL JavaScript library, you can follow this
+  [migration guide](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-compare-msal-js-and-adal-js)
+  to update to MSAL.js.
+* Existing applications relying on ADAL JavaScript will continue to work.
+
+---
+
 Active Directory Authentication Library (ADAL) for JavaScript
 ====================================
 |[Getting Started](https://github.com/Azure-Samples/active-directory-javascript-singlepageapp-dotnet-webapi)| [Docs](https://aka.ms/aaddev)| [Samples](https://github.com/azure-samples?query=active-directory)| [Support](README.md#community-help-and-support)

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -187,6 +187,8 @@ var AuthenticationContext = (function () {
         if (this.config.loadFrameTimeout) {
             this.CONSTANTS.LOADFRAME_TIMEOUT = this.config.loadFrameTimeout;
         }
+
+        this._setupCrossBrowsingContextLogoutCleanup();
     };
 
     if (typeof window !== 'undefined') {
@@ -855,7 +857,7 @@ var AuthenticationContext = (function () {
      */
     AuthenticationContext.prototype.logOut = function () {
         this.clearCache();
-        this._user = null;
+        this._clearUser();
         var urlNavigate;
 
         if (this.config.logOutUri) {
@@ -982,6 +984,14 @@ var AuthenticationContext = (function () {
         }
 
         return user;
+    };
+
+    /**
+     * Clears the user
+     * @ignore
+     */
+    AuthenticationContext.prototype._clearUser = function () {
+        this._user = null;
     };
 
     /**
@@ -1210,7 +1220,7 @@ var AuthenticationContext = (function () {
                         if (!this._matchNonce(this._user)) {
                             this._saveItem(this.CONSTANTS.STORAGE.LOGIN_ERROR, 'Nonce received: ' + this._user.profile.nonce + ' is not same as requested: ' +
                                 this._getItem(this.CONSTANTS.STORAGE.NONCE_IDTOKEN));
-                            this._user = null;
+                            this._clearUser();
                         } else {
                             this._saveItem(this.CONSTANTS.STORAGE.IDTOKEN, requestInfo.parameters[this.CONSTANTS.ID_TOKEN]);
 
@@ -1791,6 +1801,22 @@ var AuthenticationContext = (function () {
         } catch (e) {
             return false;
         }
+    };
+
+    /**
+     * Listens for logouts on other browsing contexts. Clears the user When a logout is detected.
+     * @ignore
+     */
+    AuthenticationContext.prototype._setupCrossBrowsingContextLogoutCleanup = function () {
+        var clearUserOnExternalBrowsingContextLogout = function (evt) {
+            var isExternalBrowsingContextLogout = evt.key === this.CONSTANTS.STORAGE.IDTOKEN && evt.oldValue !== '' && evt.newValue === '';
+
+            if (isExternalBrowsingContextLogout) {
+                this._clearUser();
+            }
+        };
+
+        window.addEventListener('storage', clearUserOnExternalBrowsingContextLogout.bind(this));
     };
 
     /**

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -86,6 +86,13 @@ describe('Adal', function () {
             }
         };
     }();
+    var eventListeners = {};
+    var addEventListenerFake = function (type, callback) {
+        if (!eventListeners[type]) {
+            eventListeners[type] = [];
+        }
+        eventListeners[type].push(callback);
+    };
 
     beforeEach(function () {
 
@@ -111,6 +118,7 @@ describe('Adal', function () {
             innerWidth: 100,
             innerHeight: 100
         };
+        window.addEventListener = addEventListenerFake;
         window.localStorage = storageFake;
         window.sessionStorage = storageFake;
         // Init adal 
@@ -128,6 +136,17 @@ describe('Adal', function () {
         window.renewStates = [];
         adal._activeRenewals = {};
         adal.CONSTANTS.LOADFRAME_TIMEOUT = 800;
+    });
+
+    it('cleans up the user when an external browsing context logs out', function () {
+        adal._user = { profile: { 'upn': 'test@testuser.com' }, userName: 'test@domain.com' };
+        var externalLogoutStorageEvent = { key: adal.CONSTANTS.STORAGE.IDTOKEN, oldValue: 'token', newValue: '' };
+
+        waitsFor(function () {
+            var externalLogoutStorageListener = eventListeners['storage'][0];
+            externalLogoutStorageListener(externalLogoutStorageEvent);
+            return adal._user === null;
+        }, 'user not cleared', 1000);
     });
 
     it('gets specific resource for defined endpoint mapping', function () {
@@ -1020,11 +1039,9 @@ describe('Adal', function () {
     });
 
     it('tests default value of redirect uri', function () {
-        global.window = {
-            location: {
-                hash: '#/hash',
-                href: 'https://www.testurl.com/#/hash?q1=p1'
-            }
+        global.window.location = {
+            hash: '#/hash',
+            href: 'https://www.testurl.com/#/hash?q1=p1'
         };
         AdalModule.prototype._singletonInstance = null;
         var localConfig = { clientId: 'e9a5a8b6-8af7-4719-9821-0deef255f68e' };


### PR DESCRIPTION
Problem overview
---
Currently, if a user has open multiple browsing contexts (tabs, windows, etc) of an application that uses ADAL, logout does not sync across the tabs. When `logOut` is called in one tab, others continue to maintain `this._user` in memory. Therefore, calls to `getUser` and `getCachedUser` in these tabs will continue to return a user object, even though the localStorage/sessionStorage entries have been removed and the user should be considered "logged out".

Effect on Yammer
---
Yammer is using an authenticator that checks for user presence as part of determining if a login is required during token acquisition. When a logout has occurred in one tab, and acquireToken is then called in another tab, the second tab would still be considered "logged-in", because `getCachedUser` still returns a user. As a result, acquireToken would be called when no `login.microsoftonline.com` cookies exist, causing ADAL to return `AADSTS50058` (cookies not found error) and Yammer to display a third party cookie configuration error page.

Proposed fix
---
This PR adds a mechanism to clear the user when an external browsing context of the same origin performs a logout. The approach uses [storage events](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) instead of something like the [broadcast channel api](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) to maintain compatibility with browsers supported by Yammer (specifically IE11 and Safari).