### PR TITLE
use self._activeRenewals to decide whether we should trigger timeout

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -589,14 +589,14 @@ var AuthenticationContext = (function () {
         var self = this;
 
         setTimeout(function () {
-            if (self._getItem(self.CONSTANTS.STORAGE.RENEW_STATUS + resource) === self.CONSTANTS.TOKEN_RENEW_STATUS_IN_PROGRESS) {
-                // fail the iframe session if it's in pending state
+            if (self._activeRenewals[resource]) {
+                // fail the iframe session when times out and there are active toke renewals
                 self.verbose('Loading frame has timed out after: ' + (self.CONSTANTS.LOADFRAME_TIMEOUT / 1000) + ' seconds for resource ' + resource);
                 var expectedState = self._activeRenewals[resource];
                 self._activeRenewals[resource] = null;
                 self._saveItem(self.CONSTANTS.STORAGE.RENEW_STATUS + resource, self.CONSTANTS.TOKEN_RENEW_STATUS_CANCELED);
 
-                if (expectedState && self._callBackMappedToRenewStates[expectedState]) {
+                if (self._callBackMappedToRenewStates[expectedState]) {
                     self._callBackMappedToRenewStates[expectedState]('Token renewal operation failed due to timeout', null, 'Token Renewal Failed');
                 }
             }
@@ -1686,7 +1686,7 @@ var AuthenticationContext = (function () {
      * @ignore
      */
     AuthenticationContext.prototype._now = function () {
-        return Math.round(new Date().getTime() / 1000.0);
+        return Math.round(Date.now() / 1000.0);
     };
 
     /**

--- a/lib/adal.js
+++ b/lib/adal.js
@@ -590,7 +590,7 @@ var AuthenticationContext = (function () {
 
         setTimeout(function () {
             if (self._activeRenewals[resource]) {
-                // fail the iframe session when times out and there are active toke renewals
+                // fail the iframe session when times out and there are active token renewals
                 self.verbose('Loading frame has timed out after: ' + (self.CONSTANTS.LOADFRAME_TIMEOUT / 1000) + ' seconds for resource ' + resource);
                 var expectedState = self._activeRenewals[resource];
                 self._activeRenewals[resource] = null;

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -683,7 +683,6 @@ describe('Adal', function () {
             return storageFake.getItem(adal.CONSTANTS.STORAGE.RENEW_STATUS + RESOURCE1) === adal.CONSTANTS.TOKEN_RENEW_STATUS_CANCELED;
         }, 'token renew status not updated', 1000);
         runs(function () {
-            adal._callBackMappedToRenewStates[adal.config.state]('Token renewal operation failed due to timeout', null, 'Token Renewal Failed');
             expect(storageFake.getItem(adal.CONSTANTS.STORAGE.RENEW_STATUS + RESOURCE1)).toBe(adal.CONSTANTS.TOKEN_RENEW_STATUS_CANCELED);
             expect(errDesc).toBe('Token renewal operation failed due to timeout');
             expect(token).toBe(null);

--- a/tests/unit/spec/AdalSpec.js
+++ b/tests/unit/spec/AdalSpec.js
@@ -643,6 +643,7 @@ describe('Adal', function () {
     });
 
     it('tests the load frame timeout method', function () {
+        adal._activeRenewals[RESOURCE1] = '123456|' + RESOURCE1 + '|1591896469';
         adal._loadFrameTimeout('urlnavigation', 'frameName', RESOURCE1);
         expect(storageFake.getItem(adal.CONSTANTS.STORAGE.RENEW_STATUS + RESOURCE1)).toBe(adal.CONSTANTS.TOKEN_RENEW_STATUS_IN_PROGRESS);
 
@@ -687,7 +688,6 @@ describe('Adal', function () {
             expect(errDesc).toBe('Token renewal operation failed due to timeout');
             expect(token).toBe(null);
             expect(err).toBe('Token Renewal Failed');
-
         });
     });
 


### PR DESCRIPTION
use self._activeRenewals to decide whether we should trigger timeout clean ups, instead of 'self.CONSTANTS.STORAGE.RENEW_STATUS + resource' since it could be changed by other tabs.