### PR TITLE
fixing timing issue with redirect

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1362,7 +1362,9 @@ var AuthenticationContext = (function () {
 
             if (window.parent === window && !isPopup) {
                 if (self.config.navigateToLoginRequestUrl) {
-                    window.location.href = self._getItem(self.CONSTANTS.STORAGE.LOGIN_REQUEST);
+                    var navigateUrl = self._getItem(self.CONSTANTS.STORAGE.LOGIN_REQUEST);
+                    window.setTimeout(function(){window.location.href = navigateUrl;}, 0);
+                    window.location.href = navigateUrl;
                 } else window.location.hash = '';
             }
         }


### PR DESCRIPTION
this will cancel out any previous schedule attempt to redirect and let handleWindowCallback to redirect to correct originating url.

Issue - 
when we trying to attempt silent signin with "prompt=none" (with redirect), first attempt work fine and login.microsoft.com first redirect to teams.microsoft.com with error_description in url hash and then adal.js redirect browser to originating url i.e. teams.microsoft.com (expected behavior)

Now, if we refresh page, again teams.microsoft.com try to silent signin with prompt=none, but when login.microsoftonline.com redirect back to teams.microsoft.com with error_description in url hash, adal.js instead of redirecting back to originating url, it redirect again to login.microsoftonline.com without prompt=none.

This seems like some scheduling of redirect to login.microsoftonline.com. So even with location.href=<originating url>, it always redirect to login.microsoftonline.com.

example:
setTimeout(function(){window.location.href="https://www.msn.com"},100);window.location.href="https://www.google.com";

proposed fix, will make sure to redirect to expected url and resolve any timing issue with href change.
