### PR TITLE
correctly set iframe border width to 0

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1709,7 +1709,7 @@ var AuthenticationContext = (function () {
                 ifr.setAttribute('aria-hidden', 'true');
                 ifr.style.visibility = 'hidden';
                 ifr.style.position = 'absolute';
-                ifr.style.width = ifr.style.height = ifr.borderWidth = '0px';
+                ifr.style.width = ifr.style.height = ifr.style.borderWidth = '0px';
 
                 adalFrame = document.getElementsByTagName('body')[0].appendChild(ifr);
             }


### PR DESCRIPTION
The `borderWidth` attribute was being set directly on the iframe element, when it should instead be set on the iframe's `style` object.

This bug enabled the token refresh iframe to take up space when borderWidth was not globally set to 0, resulting in elements shifting and extra scrollbars being created.